### PR TITLE
Use dnf instead of microdnf

### DIFF
--- a/moduleframework/common.py
+++ b/moduleframework/common.py
@@ -115,7 +115,7 @@ dusername = "test"
 dpassword = "test"
 ddatabase = "basic"
 hostpackager = "yum -y"
-guestpackager = "microdnf"
+guestpackager = "dnf"
 if os.path.exists('/usr/bin/dnf'):
     hostpackager = "dnf -y"
 ARCH = "x86_64"

--- a/moduleframework/dockerlinter.py
+++ b/moduleframework/dockerlinter.py
@@ -173,18 +173,16 @@ class DockerfileLinter(object):
         if FROM in self.docker_dict:
             return [x for x in self.docker_dict[FROM] if "baseruntime/baseruntime" in x]
 
-    def check_microdnf(self):
+    def check_dnf(self):
         """
         Function returns docker labels
         :return: label dictionary
         """
         if RUN in self.docker_dict:
             for val in self.docker_dict[RUN]:
-                if val.startswith("yum") or " yum " in val:
-                    return False
                 if val.startswith("dnf") or " dnf " in val:
-                    return False
-                else:
                     return True
+                else:
+                    return False
 
 

--- a/tools/modulelint.py
+++ b/tools/modulelint.py
@@ -47,7 +47,7 @@ class DockerfileLinter(module_framework.AvocadoTest):
         self.assertTrue(self.dp.check_baseruntime())
 
     def testDockerRunMicrodnf(self):
-        self.assertTrue(self.dp.check_microdnf())
+        self.assertTrue(self.dp.check_dnf())
 
     def testArchitectureInEnvAndLabelExists(self):
         self.assertTrue(self.dp.get_docker_specific_env("ARCH="))


### PR DESCRIPTION
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>

I totally forgot to mention reason.
In Dockerfile file we test whether it uses microdnf and not dnf. Unfortunately, it was changed.
Now we should check whether Dockerfile contains dnf and not microdnf. dnf turn on modularity in Dockerfiles.