### PR TITLE
Tests whether dnf contains --nodocs and clean all

### DIFF
--- a/moduleframework/dockerlinter.py
+++ b/moduleframework/dockerlinter.py
@@ -173,18 +173,24 @@ class DockerfileLinter(object):
         if FROM in self.docker_dict:
             return [x for x in self.docker_dict[FROM] if "baseruntime/baseruntime" in x]
 
-    def check_microdnf(self):
+    def check_dnf_nodocs_flag(self):
         """
         Function returns docker labels
         :return: label dictionary
         """
         if RUN in self.docker_dict:
-            for val in self.docker_dict[RUN]:
-                if val.startswith("yum") or " yum " in val:
-                    return False
-                if val.startswith("dnf") or " dnf " in val:
-                    return False
-                else:
-                    return True
+            if '--nodocs' in self.docker_dict[RUN]:
+                return True
+            else:
+                return False
 
-
+    def check_dnf_cleanall(self):
+        """
+        Function returns docker labels
+        :return: label dictionary
+        """
+        if RUN in self.docker_dict:
+            if 'clean' in self.docker_dict[RUN] and 'all' in self.docker_dict[RUN]:
+                return True
+            else:
+                return False

--- a/tools/modulelint.py
+++ b/tools/modulelint.py
@@ -45,8 +45,11 @@ class DockerfileLinter(module_framework.AvocadoTest):
     def testDockerFromBaseruntime(self):
         self.assertTrue(self.dp.check_baseruntime())
 
-    def testDockerRunMicrodnf(self):
-        self.assertTrue(self.dp.check_microdnf())
+    def testDockerDNFNodocs(self):
+        self.assertTrue(self.dp.check_dnf_nodocs_flag())
+
+    def testDockerDNFCleanAll(self):
+        self.assertTrue(self.dp.check_dnf_cleanall())
 
     def testArchitectureInEnvAndLabelExists(self):
         self.assertTrue(self.dp.get_docker_specific_env("ARCH="))


### PR DESCRIPTION
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>

This Pull Request tests whether dnf or yum contains --nodocs and clean all commands in RUN section.
testing of microdnf was removed. It does not make sense at all. Container developer can use either microdnf, dnf or even yum in CentOS word.