### PR TITLE
MTF renaming

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,8 @@
 # vi: set ft=ruby :
 # -*- coding: utf-8 -*-
 #
-# This Modularity Testing Framework helps you to write tests for modules
+# Meta test family (MTF) is a tool to test components of a modular Fedora:
+# https://docs.pagure.org/modularity/
 # Copyright (C) 2017 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify
@@ -24,7 +25,7 @@
 Vagrant.configure(2) do |config|
 
     config.vm.box = "fedora/25-cloud-base"
-    config.vm.synced_folder ".", "/home/vagrant/modularity-testing-framework"
+    config.vm.synced_folder ".", "/home/vagrant/meta-test-family"
     config.vm.network "private_network", ip: "192.168.50.10"
     config.vm.network "forwarded_port", guest: 80, host: 8888
     config.vm.hostname = "moduletesting"
@@ -43,7 +44,7 @@ Vagrant.configure(2) do |config|
     config.vm.provision "shell", inline: <<-SHELL
         set -x
         dnf install -y make docker httpd git python2-avocado python2-avocado-plugins-output-html python-netifaces
-        cd /home/vagrant/modularity-testing-framework
+        cd /home/vagrant/meta-test-family
         make install
         make check
         cp -r /root/avocado /var/www/html/

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -3,7 +3,7 @@ API Index
 
 This section contains the MTF API, auto generated from `the source code`_.
 
-.. _the source code: https://pagure.io/modularity-testing-framework
+.. _the source code: https://github.com/fedora-modularity/meta-test-family
 
 .. toctree::
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# modularity-testing-framework documentation build configuration file, created by
+# meta-test-family documentation build configuration file, created by
 # sphinx-quickstart on Tue Apr 21 13:42:00 2015.
 #
 # This file is execfile()d with the current directory set to its
@@ -64,7 +64,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'modularity-testing-framework'
+project = u'meta-test-family'
 copyright = u'2017, Red Hat'
 
 # The version info for the project you're documenting, acts as replacement for
@@ -189,7 +189,7 @@ html_theme_path = [] if on_rtd else [sphinx_rtd_theme.get_html_theme_path()]
 #html_file_suffix = None
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'ModularityTestingFrameworkDoc'
+htmlhelp_basename = 'MetaTestFamilyDoc'
 
 
 # -- Options for LaTeX output ---------------------------------------------
@@ -209,7 +209,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  (master_doc, 'ModularityTestingFramework.tex', u'Modularity Testing Framework Documentation',
+  (master_doc, 'MetaTestFamily.tex', u'Meta Test Family Documentation',
    u'Petr Hracek \\and Jan Scotka', 'manual'),
 ]
 
@@ -239,7 +239,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('manpage', 'modularity-testing-framework',
+    ('manpage', 'meta-test-family',
      u'helps you with writing tests for you modules and containers',
      [u'Petr Hracek', u'Jan Scotka'], 1),
 ]
@@ -254,8 +254,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  (master_doc, 'ModularityTestingFramework', u'Modularity Testing Framework Documentation',
-   u'Petr Hracek@*Jan Scotka', 'ModularityTestingFramework', 'One line description of project.',
+  (master_doc, 'MetaTestfamily', u'Meta Test family Documentation',
+   u'Petr Hracek@*Jan Scotka', 'MetaTestFamily', 'One line description of project.',
    'Miscellaneous'),
 ]
 

--- a/docs/example-config-minimal.yaml
+++ b/docs/example-config-minimal.yaml
@@ -1,1 +1,15 @@
-user_guide/example_config_minimal.yaml
+document: modularity-testing
+version: 1
+name: bash
+modulemd-url: https://src.fedoraproject.org/cgit/modules/memcached.git/plain/memcached.yaml
+packages:
+    rpms:
+        - bash
+        - rpm
+module:
+    docker:
+        container: docker.io/phracek/memcached
+    rpm:
+        repo: https://kojipkgs.fedoraproject.org/compose/latest-Fedora-Modular-26/compose/Server/x86_64/os/
+
+

--- a/docs/example-config.yaml
+++ b/docs/example-config.yaml
@@ -1,9 +1,9 @@
 # identifier of document for modularity testing framework
-# COPY of https://pagure.io/modularity-testing-framework/blob/master/f/docs/example-config.yaml
+# COPY of https://github.com/fedora-modularity/meta-test-family/blob/master/docs/example-config.yaml
 # if your module does not provide any service, you can use minimal version:
-# https://pagure.io/modularity-testing-framework/blob/master/f/docs/example-config-minimal.yaml
+# https://github.com/fedora-modularity/meta-test-family/blob/master/docs/example-config-minimal.yaml
 # MANDATORY
-document: modularity-testing
+document: meta-test
 # MANDATORY
 version: 1
 # name of module for testing (it should be same as moduleMD yaml file without extension)
@@ -45,7 +45,7 @@ module:
     docker:
 # run setup/cleanup commands on HOST, for example config manipulation, selinux boolean manipulation
 # there could be used also variables in python style like: {ROOT}, {HOSTNAME} see
-# trans_dict in  file https://pagure.io/modularity-testing-framework/blob/master/f/moduleframework/module_framework.py
+# trans_dict in  file https://github.com/fedora-modularity/meta-test-family/blob/master/moduleframework/module_framework.py
         setup: echo Do magic with general config stored on host;
                echo More magic
         cleanup: echo Cleanup magic
@@ -82,4 +82,3 @@ module:
         repos:
             - https://kojipkgs.stg.fedoraproject.org/compose/branched/jkaluza/latest-Fedora-Modular-26/compose/Server/x86_64/os/
             - https://kojipkgs.fedoraproject.org/compose/latest-Fedora-Modular-26/compose/Server/x86_64/os/
-

--- a/docs/how_to_schedule.rst
+++ b/docs/how_to_schedule.rst
@@ -67,5 +67,5 @@ Multihost
 - Internal logic of testing
     - could be same as previous ones that there is one *Host* and one  *Guest* machine what can cooperate togetger
     - Or it could be used for general multihost testing with *N* machines where *N>1* via use backends directly in setUp sections
-        - see example of test: https://pagure.io/modularity-testing-framework/blob/master/f/examples/multios_testing/sanityRealMultiHost.py
+        - see example of test: https://github.com/fedora-modularity/meta-test-family/blob/master/examples/multios_testing/sanityRealMultiHost.py
         - this example creates 3 machines *(using nspawn)* with various fedora versions and gather data.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,12 +1,12 @@
-Modularity Testing Framework Documentation
+Meta Test Family Documentation
 ==========================================
 
-Welcome to the Modularity Testing Framework documentation!
+Welcome to the Meta Test Family documentation!
 
 About
 =====
 
-Modularity testing framework (MTF) is a tool to test components of `a modular Fedora`_.
+**M**eta **T**est **F**amily (MTF) is a tool to test components of `a modular Fedora`_.
 
 Using MTF you can:
 
@@ -22,12 +22,12 @@ MTF has a presence on the following websites:
 
 * `Documentation`_ is available on ReadTheDocs.
 * A `Package repository`_ is available on Fedora Copr.
-* `MTF's code`_ and the issue tracker for sharing bugs and feature ideas are stored on Pagure.
+* `MTF's code`_ and the issue tracker for sharing bugs and feature ideas are stored on GitHub.
 
-.. _Documentation: http://modularity-testing-framework.readthedocs.io
+.. _Documentation: http://meta-test-family.readthedocs.io
 .. _a modular Fedora: https://docs.pagure.org/modularity/
 .. _Package repository: https://copr.fedorainfracloud.org/coprs/phracek/Modularity-testing-framework/
-.. _MTF's code: https://pagure.io/modularity-testing-framework
+.. _MTF's code: https://github.com/fedora-modularity/meta-test-family
 
 Content
 =======

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,7 +26,7 @@ MTF has a presence on the following websites:
 
 .. _Documentation: http://meta-test-family.readthedocs.io
 .. _a modular Fedora: https://docs.pagure.org/modularity/
-.. _Package repository: https://copr.fedorainfracloud.org/coprs/phracek/Modularity-testing-framework/
+.. _Package repository: https://copr.fedorainfracloud.org/coprs/phracek/meta-test-family/
 .. _MTF's code: https://github.com/fedora-modularity/meta-test-family
 
 Content

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -6,14 +6,15 @@ There are two ways to install and use MTF: to set up it locally or alternatively
 .. contents:: Topics
 
 .. _using_vagrant:
+
 Vagrant
 ---------------------
 
-`Vagrant`_ is a tool to aid developers in quickly deploying development environments. There is a `Vagrantfile`_ in the `modularity-testing-framework`_ git repository on Pagure that can automatically deploy a virtual machine on your host with a MTF environment configured.
+`Vagrant`_ is a tool to aid developers in quickly deploying development environments. There is a `Vagrantfile`_ in the `meta-test-family`_ git repository on GitHub that can automatically deploy a virtual machine on your host with a MTF environment configured.
 
 .. _Vagrant: https://docs.vagrantup.com/
-.. _Vagrantfile: https://pagure.io/modularity-testing-framework/blob/master/f/Vagrantfile
-.. _modularity-testing-framework: https://pagure.io/modularity-testing-framework
+.. _Vagrantfile: https://github.com/fedora-modularity/meta-test-family/blob/master/Vagrantfile
+.. _meta-test-family: https://github.com/fedora-modularity/meta-test-family.git
 
 The MTF tool has been made available for use of two providers: ``libvirt`` (for Linux host only) and ``virtualbox`` (for MAC OS, Windows and Linux hosts), where ``libvirt`` is a default one. See more about Vagrant providers `here`_.
 
@@ -54,14 +55,14 @@ After preparing the libvirt prerequisites using the instructions above:
 
    # cd to your prefered location
    $ cd $HOME/  # Season to taste.
-   $ git clone https://pagure.io/modularity-testing-framework.git
+   $ git clone https://github.com/fedora-modularity/meta-test-family.git
 
-2. Next, enter into the ``modularity-testing-framework`` directory.
+2. Next, enter into the ``meta-test-family`` directory.
 
 .. code-block:: bash
 
-   # cd in modularity-testing-framework
-   $ cd modularity-testing-framework
+   # cd in meta-test-family
+   $ cd meta-test-family
 
 3. The MTF tool provides a configuration Vagrantfile that you can use to configure the Vagrant environment as given or open the Vagrantfile in your favorite editor and modify it to better fit your development preferences. This step is entirely optional as the default Vagrantfile should  work for most users.
 
@@ -79,7 +80,7 @@ After preparing the libvirt prerequisites using the instructions above:
       # The above will run for a while while it provisions your development environment.
       $ sudo vagrant reload  # Reboot the machine at the end to apply kernel updates, etc.
 
-5. Once you have followed the steps above, you should have a running deployed MTF development machine. Log into your Vagrant environment::
+5. Once you have followed the steps above, you should have a running deployed MTF development machine. Log into your Vagrant environment:
 
 .. code-block:: bash
 
@@ -107,8 +108,10 @@ MTF supports Gherkin-based testing in Python. To write tests in a natural langua
     $ sudo pip install behave
 
 .. _installing_mtg:
+
 Installing MTF
-~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
+
 Install MTF rpm from `Fedora Copr repo`_.
 
 .. _Fedora Copr repo: https://copr.fedorainfracloud.org/coprs/phracek/Modularity-testing-framework/
@@ -122,12 +125,13 @@ Install MTF rpm from `Fedora Copr repo`_.
 MTF scripts, examples and documentation will be installed into ``/usr/share/moduleframework``
 
 .. _getting_mtf:
+
 Source code
 -----------
 
-You may also wish to follow the `Pagure MTF repo`_ if you have a Pagure account. This stores the source code and the issue tracker for sharing bugs and feature ideas. The repository should be forked into your personal Pagure account where all work will be done. Any changes should be submitted through the pull request process.
+You may also wish to follow the `GitHub MTF repo`_ if you have a GitHub account. This stores the source code and the issue tracker for sharing bugs and feature ideas. The repository should be forked into your personal GitHub account where all work will be done. Any changes should be submitted through the pull request process.
 
-.. _Pagure MTF repo: https://pagure.io/modularity-testing-framework
+.. _GitHub MTF repo: https://github.com/fedora-modularity/meta-test-family
 
 .. seealso::
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -114,13 +114,13 @@ Installing MTF
 
 Install MTF rpm from `Fedora Copr repo`_.
 
-.. _Fedora Copr repo: https://copr.fedorainfracloud.org/coprs/phracek/Modularity-testing-framework/
+.. _Fedora Copr repo: https://copr.fedorainfracloud.org/coprs/phracek/meta-test-family/
 
 .. code-block:: bash
 
-    # add modularity-testing-framework yum repo
-    $ sudo dnf copr enable phracek/Modularity-testing-framework
-    $ sudo dnf install -y modularity-testing-framework
+    # add meta-test-family yum repo
+    $ sudo dnf copr enable phracek/meta-test-family
+    $ sudo dnf install -y meta-test-family
 
 MTF scripts, examples and documentation will be installed into ``/usr/share/moduleframework``
 

--- a/docs/license.rst
+++ b/docs/license.rst
@@ -3,4 +3,4 @@ License
 
 MTF is released under the GPLv2+, see `LICENSE`_ file in the source code repository.
 
-.. _LICENSE: https://pagure.io/modularity-testing-framework/blob/master/f/LICENSE
+.. _LICENSE: https://github.com/fedora-modularity/meta-test-family/blob/master/LICENSE

--- a/docs/user_guide/how_to_write_conf_file.rst
+++ b/docs/user_guide/how_to_write_conf_file.rst
@@ -3,8 +3,8 @@ Configuration file
 
 To test a module create its configuration file ``config.yaml`` similar to an `example configuration file`_ described further. If the tested module doesn't represent any service, the `minimal configuration file`_ structure can be used.
 
-.. _example configuration file: https://pagure.io/modularity-testing-framework/blob/master/f/examples/memcached/config.yaml
-.. _minimal configuration file: https://pagure.io/modularity-testing-framework/blob/master/f/docs/example-config-minimal.yaml
+.. _example configuration file: https://github.com/fedora-modularity/meta-test-family/blob/master/examples/memcached/config.yaml
+.. _minimal configuration file: https://github.com/fedora-modularity/meta-test-family/blob/master/docs/example-config-minimal.yaml
 
 An example of ``config.yaml`` header:
 

--- a/docs/user_guide/index.rst
+++ b/docs/user_guide/index.rst
@@ -15,7 +15,7 @@ User Guide
 
 4. Write your tests, for example see `sanity tests`_ and various tests examples in ``/usr/share/moduleframework/examples/testing-module/``. All tests methods are listed in section `API Index`_ and alphabetically in :ref:`genindex` section.
 
-.. _sanity tests: https://pagure.io/modularity-testing-framework/blob/master/f/examples/template/sanity_template.py
+.. _sanity tests: https://github.com/fedora-modularity/meta-test-family/blob/master/examples/template/sanity_template.py
 .. _API Index: ../api/index
 
 5. In the directory ``tests`` create a ``Makefile`` as below.

--- a/docs/user_guide/troubleshooting.rst
+++ b/docs/user_guide/troubleshooting.rst
@@ -2,7 +2,7 @@ Troubleshooting
 ===============
 
 First test takes so long time
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 It is expected behavior, because the first test run downloads all packages from Koji and creates a local
 repo. It is workaround because of missing composes for modules (on demand done by pungi). To make tests execute faster use environment variables:
@@ -11,7 +11,7 @@ repo. It is workaround because of missing composes for modules (on demand done b
     - **MTF_DO_NOT_CLEANUP=yes** to disable cleaup between tests. Use only if there is no interference in between tests.
 
 Unable to debug avocado output errors
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you see an error: ``Avocado crashed: TestError: Process died before it pushed early test_status.``, add environment variables:
 

--- a/examples/base-runtime/config.yaml
+++ b/examples/base-runtime/config.yaml
@@ -1,4 +1,4 @@
-document: modularity-testing
+document: meta-test
 version: 1
 name: baseruntime
 modulemd-url: http://pkgs.fedoraproject.org/cgit/modules/base-runtime.git/plain/base-runtime.yaml

--- a/examples/base-runtime/sanity1.py
+++ b/examples/base-runtime/sanity1.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# This Modularity Testing Framework helps you to write tests for modules
+# Meta test family (MTF) is a tool to test components of a modular Fedora:
+# https://docs.pagure.org/modularity/
 # Copyright (C) 2017 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/examples/base-runtime/sanity2.py
+++ b/examples/base-runtime/sanity2.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# This Modularity Testing Framework helps you to write tests for modules
+# Meta test family (MTF) is a tool to test components of a modular Fedora:
+# https://docs.pagure.org/modularity/
 # Copyright (C) 2017 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/examples/haproxy/config.yaml
+++ b/examples/haproxy/config.yaml
@@ -1,4 +1,4 @@
-document: modularity-testing
+document: meta-test
 version: 1
 name: haproxy
 modulemd-url: https://raw.githubusercontent.com/container-images/haproxy/master/haproxy.yaml

--- a/examples/haproxy/simpleTest.py
+++ b/examples/haproxy/simpleTest.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# This Modularity Testing Framework helps you to write tests for modules
+# Meta test family (MTF) is a tool to test components of a modular Fedora:
+# https://docs.pagure.org/modularity/
 # Copyright (C) 2017 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/examples/memcached-behave/environment.py
+++ b/examples/memcached-behave/environment.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# This Modularity Testing Framework helps you to write tests for modules
+# Meta test family (MTF) is a tool to test components of a modular Fedora:
+# https://docs.pagure.org/modularity/
 # Copyright (C) 2017 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/examples/memcached-behave/steps/steps.py
+++ b/examples/memcached-behave/steps/steps.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# This Modularity Testing Framework helps you to write tests for modules
+# Meta test family (MTF) is a tool to test components of a modular Fedora:
+# https://docs.pagure.org/modularity/
 # Copyright (C) 2017 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/examples/memcached/config.yaml
+++ b/examples/memcached/config.yaml
@@ -1,4 +1,4 @@
-document: modularity-testing
+document: meta-test
 version: 1
 name: memcached
 modulemd-url: http://raw.githubusercontent.com/container-images/memcached/master/memcached.yaml

--- a/examples/memcached/sanity1.py
+++ b/examples/memcached/sanity1.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# This Modularity Testing Framework helps you to write tests for modules
+# Meta test family (MTF) is a tool to test components of a modular Fedora:
+# https://docs.pagure.org/modularity/
 # Copyright (C) 2017 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/examples/memcached/sanity2.sh
+++ b/examples/memcached/sanity2.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
 #
-# This Modularity Testing Framework helps you to write tests for modules
+# Meta test family (MTF) is a tool to test components of a modular Fedora:
+# https://docs.pagure.org/modularity/
 # Copyright (C) 2017 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/examples/multios_testing/config.yaml
+++ b/examples/multios_testing/config.yaml
@@ -1,4 +1,4 @@
-document: modularity-testing
+document: meta-test
 version: 1
 name: nc
 packages:

--- a/examples/multios_testing/sanity1.py
+++ b/examples/multios_testing/sanity1.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# This Modularity Testing Framework helps you to write tests for modules
+# Meta test family (MTF) is a tool to test components of a modular Fedora:
+# https://docs.pagure.org/modularity/
 # Copyright (C) 2017 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/examples/multios_testing/sanityRealMultiHost.py
+++ b/examples/multios_testing/sanityRealMultiHost.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# This Modularity Testing Framework helps you to write tests for modules
+# Meta test family (MTF) is a tool to test components of a modular Fedora:
+# https://docs.pagure.org/modularity/
 # Copyright (C) 2017 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/examples/nginx/config.yaml
+++ b/examples/nginx/config.yaml
@@ -1,4 +1,4 @@
-document: modularity-testing
+document: meta-test
 version: 1
 name: ngnix
 modulemd-url: https://raw.githubusercontent.com/container-images/nginx/master/nginx.yaml

--- a/examples/nginx/sanity1.py
+++ b/examples/nginx/sanity1.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# This Modularity Testing Framework helps you to write tests for modules
+# Meta test family (MTF) is a tool to test components of a modular Fedora:
+# https://docs.pagure.org/modularity/
 # Copyright (C) 2017 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/examples/template/config.yaml
+++ b/examples/template/config.yaml
@@ -1,4 +1,4 @@
-document: modularity-testing
+document: meta-test
 version: 1
 name: Module name
 modulemd-url: URL to Raw format of YAML file

--- a/examples/template/sanity_template.py
+++ b/examples/template/sanity_template.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# This Modularity Testing Framework helps you to write tests for modules
+# Meta test family (MTF) is a tool to test components of a modular Fedora:
+# https://docs.pagure.org/modularity/
 # Copyright (C) 2017 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/examples/testing-module/PureAvocadoTest.py
+++ b/examples/testing-module/PureAvocadoTest.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# This Modularity Testing Framework helps you to write tests for modules
+# Meta test family (MTF) is a tool to test components of a modular Fedora:
+# https://docs.pagure.org/modularity/
 # Copyright (C) 2017 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/examples/testing-module/copyTest.py
+++ b/examples/testing-module/copyTest.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# This Modularity Testing Framework helps you to write tests for modules
+# Meta test family (MTF) is a tool to test components of a modular Fedora:
+# https://docs.pagure.org/modularity/
 # Copyright (C) 2017 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/examples/testing-module/escapingTest.py
+++ b/examples/testing-module/escapingTest.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# This Modularity Testing Framework helps you to write tests for modules
+# Meta test family (MTF) is a tool to test components of a modular Fedora:
+# https://docs.pagure.org/modularity/
 # Copyright (C) 2017 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/examples/testing-module/microdnfinside.py
+++ b/examples/testing-module/microdnfinside.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# This Modularity Testing Framework helps you to write tests for modules
+# Meta test family (MTF) is a tool to test components of a modular Fedora:
+# https://docs.pagure.org/modularity/
 # Copyright (C) 2017 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/examples/testing-module/rpmvalidator.py
+++ b/examples/testing-module/rpmvalidator.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# This Modularity Testing Framework helps you to write tests for modules
+# Meta test family (MTF) is a tool to test components of a modular Fedora:
+# https://docs.pagure.org/modularity/
 # Copyright (C) 2017 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/examples/testing-module/shellTest.sh
+++ b/examples/testing-module/shellTest.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
 #
-# This Modularity Testing Framework helps you to write tests for modules
+# Meta test family (MTF) is a tool to test components of a modular Fedora:
+# https://docs.pagure.org/modularity/
 # Copyright (C) 2017 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/examples/testing-module/simpleTest.py
+++ b/examples/testing-module/simpleTest.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# This Modularity Testing Framework helps you to write tests for modules
+# Meta test family (MTF) is a tool to test components of a modular Fedora:
+# https://docs.pagure.org/modularity/
 # Copyright (C) 2017 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/examples/testing-module/skipTest.py
+++ b/examples/testing-module/skipTest.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# This Modularity Testing Framework helps you to write tests for modules
+# Meta test family (MTF) is a tool to test components of a modular Fedora:
+# https://docs.pagure.org/modularity/
 # Copyright (C) 2017 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/meta-test-family.spec
+++ b/meta-test-family.spec
@@ -1,13 +1,13 @@
 %global framework_name moduleframework
 
-Name:           modularity-testing-framework
+Name:           meta-test-family
 Version:        0.5.18
 Release:        1%{?dist}
-Summary:        Framework for writing tests for modules and containers
+Summary:        Tool to test components of a modular Fedora
 
 License:        GPLv2+
-URL:            https://pagure.io/modularity-testing-framework
-Source0:        http://releases.pagure.org/%{name}/%{name}-%{version}.tar.gz
+URL:            https://github.com/fedora-modularity/meta-test-family
+Source0:        https://codeload.github.com/fedora-modularity/%{name}/tar.gz/%{name}-%{version}.tar.gz
 BuildArch:      noarch
 # Exlcude ppc64: there is no docker package on ppc64
 # https://bugzilla.redhat.com/show_bug.cgi?id=1465176

--- a/moduleframework/bashhelper.py
+++ b/moduleframework/bashhelper.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# This Modularity Testing Framework helps you to write tests for modules
+# Meta test family (MTF) is a tool to test components of a modular Fedora:
+# https://docs.pagure.org/modularity/
 # Copyright (C) 2017 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify
@@ -22,7 +23,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# This Modularity Testing Framework helps you to write tests for modules
+# Meta test family (MTF) is a tool to test components of a modular Fedora:
+# https://docs.pagure.org/modularity/
 # Copyright (C) 2017 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/moduleframework/common.py
+++ b/moduleframework/common.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# This Modularity Testing Framework helps you to write tests for modules
+# Meta test family (MTF) is a tool to test components of a modular Fedora:
+# https://docs.pagure.org/modularity/
 # Copyright (C) 2017 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/moduleframework/compose_info.py
+++ b/moduleframework/compose_info.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# This Modularity Testing Framework helps you to write tests for modules
+# Meta test family (MTF) is a tool to test components of a modular Fedora:
+# https://docs.pagure.org/modularity/
 # Copyright (C) 2017 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/moduleframework/module_framework.py
+++ b/moduleframework/module_framework.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# This Modularity Testing Framework helps you to write tests for modules
+# Meta test family (MTF) is a tool to test components of a modular Fedora:
+# https://docs.pagure.org/modularity/
 # Copyright (C) 2017 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/moduleframework/mtf_generator.py
+++ b/moduleframework/mtf_generator.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# This Modularity Testing Framework helps you to write tests for modules
+# Meta test family (MTF) is a tool to test components of a modular Fedora:
+# https://docs.pagure.org/modularity/
 # Copyright (C) 2017 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/moduleframework/pdc_data.py
+++ b/moduleframework/pdc_data.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# This Modularity Testing Framework helps you to write tests for modules
+# Meta test family (MTF) is a tool to test components of a modular Fedora:
+# https://docs.pagure.org/modularity/
 # Copyright (C) 2017 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/moduleframework/setup.py
+++ b/moduleframework/setup.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# This Modularity Testing Framework helps you to write tests for modules
+# Meta test family (MTF) is a tool to test components of a modular Fedora:
+# https://docs.pagure.org/modularity/
 # Copyright (C) 2017 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/setup.py
+++ b/setup.py
@@ -62,13 +62,13 @@ for path in paths:
             os.path.join(root, f) for f in files]
 
 setup(
-    name='modularity-testing-framework',
+    name='meta-test-family',
     version="0.5.18",
-    description='Framework for testing modules and containers.',
+    description='Tool to test components of a modular Fedora',
     keywords='modules,containers,testing,framework',
     author='Jan Scotka',
     author_email='jscotka@redhat.com',
-    url='https://pagure.io/modularity-testing-framework',
+    url='https://github.com/fedora-modularity/meta-test-family',
     license='GPLv2+',
     packages=find_packages(exclude=['docs', 'examples', 'tools']),
     include_package_data=True,

--- a/tools/compose_info_parser.py
+++ b/tools/compose_info_parser.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# This Modularity Testing Framework helps you to write tests for modules
+# Meta test family (MTF) is a tool to test components of a modular Fedora:
+# https://docs.pagure.org/modularity/
 # Copyright (C) 2017 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/tools/find_latest_bits.py
+++ b/tools/find_latest_bits.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# This Modularity Testing Framework helps you to write tests for modules
+# Meta test family (MTF) is a tool to test components of a modular Fedora:
+# https://docs.pagure.org/modularity/
 # Copyright (C) 2017 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/tools/modulelint.py
+++ b/tools/modulelint.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# This Modularity Testing Framework helps you to write tests for modules
+# Meta test family (MTF) is a tool to test components of a modular Fedora:
+# https://docs.pagure.org/modularity/
 # Copyright (C) 2017 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/tools/modulelint/check_compose.py
+++ b/tools/modulelint/check_compose.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# This Modularity Testing Framework helps you to write tests for modules
+# Meta test family (MTF) is a tool to test components of a modular Fedora:
+# https://docs.pagure.org/modularity/
 # Copyright (C) 2017 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/tools/modulelint/rpmvalidation.py
+++ b/tools/modulelint/rpmvalidation.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# This Modularity Testing Framework helps you to write tests for modules
+# Meta test family (MTF) is a tool to test components of a modular Fedora:
+# https://docs.pagure.org/modularity/
 # Copyright (C) 2017 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/tools/run-avocado-tests.sh
+++ b/tools/run-avocado-tests.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
 #
-# This Modularity Testing Framework helps you to write tests for modules
+# Meta test family (MTF) is a tool to test components of a modular Fedora:
+# https://docs.pagure.org/modularity/
 # Copyright (C) 2017 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/tools/run-them.sh
+++ b/tools/run-them.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # -*- coding: utf-8 -*-
 #
-# This Modularity Testing Framework helps you to write tests for modules
+# Meta test family (MTF) is a tool to test components of a modular Fedora:
+# https://docs.pagure.org/modularity/
 # Copyright (C) 2017 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify

--- a/tools/taskotron-msg-reader.py
+++ b/tools/taskotron-msg-reader.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# This Modularity Testing Framework helps you to write tests for modules
+# Meta test family (MTF) is a tool to test components of a modular Fedora:
+# https://docs.pagure.org/modularity/
 # Copyright (C) 2017 Red Hat, Inc.
 #
 # This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
This PR is all about moving from Modularity-Testing-Framework to Meta-Test-Family

- New docs web: http://meta-test-family.readthedocs.io/en/latest/ 
- Old web is not working anymore: http://modularity-testing-framework.readthedocs.io/
- All docs files were updated accordingly. 
- When reviewing this PR, please pay a special attention to a spec (it was also renamed), a conf.py and setup.py files. I hope evrth is fine with those. 

@phracek I believe a copr MTF repo should be updated with a new name too: https://copr.fedorainfracloud.org/coprs/phracek/Modularity-testing-framework/
I didn't change docs pages which mention that repo. 

@jscotka How can we update Taskontron links: https://taskotron.fedoraproject.org/resultsdb/results?testcases=dist.modularity-testing-framework
That I also didn't change in docs. 