### PR TITLE
Fixing CI tests caused by branch testing_dnf_changes.

### DIFF
--- a/tools/modulelint.py
+++ b/tools/modulelint.py
@@ -80,13 +80,13 @@ class DockerfileLinterInContainer(container_avocado_test.ContainerAvocadoTest):
 
     def test_docker_nodocs(self):
         self.start()
-        installed_pkgs = self.run("rpm -qa --qf '%{{NAME}}\n'", ignore_status=True).stdout
+        installed_pkgs = self.run("rpm -qa --qf '%{{NAME}}\n'", verbose=False).stdout
         # This returns a list of packages defined in config.yaml for testing
         # e.g. ["bash", "rpm", "memcached"] in case of memcached
         pkgs = self.backend.getPackageList()
         list_pkg = [pkg for pkg in installed_pkgs.split('\n') if pkg in pkgs]
         for pkg in list_pkg:
-            all_docs = self.run("rpm -qd %s" % pkg).stdout
+            all_docs = self.run("rpm -qd %s" % pkg, verbose=False).stdout
             for doc in all_docs.strip().split('\n'):
                 self.assertNotEqual(0, self.run("test -e %s" % doc, ignore_status=True).exit_status)
 


### PR DESCRIPTION
This PR fixes troubles in Dockerlint.py.

The Docker tests are separated into 2 classes.
* DockerfileSanitize only sanitize Dockerfile
* DockerfileSanitizeInHost sanitize Dockerfile things inside alone container.

Tests for `make check-rpm` are mentioned here

```
22:00 $ sudo make check-rpm 
[sudo] password for phracek: 
MODULE=nspawn mtf-env-set
name of CHROOT directory:
/opt/chroot_bash_1504036867.528037
Disabling selinux
Disabling selinux
MODULE=nspawn CONFIG=./fullconfig.yaml avocado run ../../tools/modulelint/modulelint.py
JOB ID     : 6650eaf4b0e0ac24ad19265b9ea377c87a3ececc
JOB LOG    : /root/avocado/job-results/job-2017-08-29T22.01-6650eaf/job.log
 (01/15) ../../tools/modulelint/modulelint.py:DockerLint.testBasic: SKIP
 (02/15) ../../tools/modulelint/modulelint.py:DockerLint.testContainerIsRunning: SKIP
 (03/15) ../../tools/modulelint/modulelint.py:DockerLint.testLabels: SKIP
 (04/15) ../../tools/modulelint/modulelint.py:ModuleLintPackagesCheck.test: PASS (144.70 s)
 (05/15) ../../tools/modulelint/modulelint.py:DockerfileSanitize.test_docker_from_baseruntime: SKIP
 (06/15) ../../tools/modulelint/modulelint.py:DockerfileSanitize.test_architecture_in_env_and_label_exists: SKIP
 (07/15) ../../tools/modulelint/modulelint.py:DockerfileSanitize.test_name_in_env_and_label_exists: SKIP
 (08/15) ../../tools/modulelint/modulelint.py:DockerfileSanitize.test_release_label_exists: SKIP
 (09/15) ../../tools/modulelint/modulelint.py:DockerfileSanitize.test_version_label_exists: SKIP
 (10/15) ../../tools/modulelint/modulelint.py:DockerfileSanitize.test_com_red_hat_component_label_exists: SKIP
 (11/15) ../../tools/modulelint/modulelint.py:DockerfileSanitize.test_iok8s_description_exists: SKIP
 (12/15) ../../tools/modulelint/modulelint.py:DockerfileSanitize.test_io_openshift_expose_services_exists: SKIP
 (13/15) ../../tools/modulelint/modulelint.py:DockerfileSanitize.test_io_openshift_tags_exists: SKIP
 (14/15) ../../tools/modulelint/modulelint.py:DockerfileLinterInContainer.test_docker_nodocs: SKIP
 (15/15) ../../tools/modulelint/modulelint.py:DockerfileLinterInContainer.test_docker_clean_all: SKIP
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 14 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 163.61 s
JOB HTML   : /root/avocado/job-results/job-2017-08-29T22.01-6650eaf/results.html
```
Tests related to `make check-docker`
```
$ sudo make check-docker
MODULE=docker mtf-env-set
MODULE=docker CONFIG=./fullconfig.yaml avocado run ../../tools/modulelint/modulelint.py
JOB ID     : 87175563eb86074d8a171db6e06f3b7de37f3077
JOB LOG    : /root/avocado/job-results/job-2017-08-29T22.04-8717556/job.log
 (01/15) ../../tools/modulelint/modulelint.py:DockerLint.testBasic: PASS (17.46 s)
 (02/15) ../../tools/modulelint/modulelint.py:DockerLint.testContainerIsRunning: PASS (18.51 s)
 (03/15) ../../tools/modulelint/modulelint.py:DockerLint.testLabels: PASS (8.74 s)
 (04/15) ../../tools/modulelint/modulelint.py:ModuleLintPackagesCheck.test: PASS (17.48 s)
 (05/15) ../../tools/modulelint/modulelint.py:DockerfileSanitize.test_docker_from_baseruntime: PASS (5.81 s)
 (06/15) ../../tools/modulelint/modulelint.py:DockerfileSanitize.test_architecture_in_env_and_label_exists: PASS (4.24 s)
 (07/15) ../../tools/modulelint/modulelint.py:DockerfileSanitize.test_name_in_env_and_label_exists: PASS (4.20 s)
 (08/15) ../../tools/modulelint/modulelint.py:DockerfileSanitize.test_release_label_exists: PASS (3.84 s)
 (09/15) ../../tools/modulelint/modulelint.py:DockerfileSanitize.test_version_label_exists: PASS (5.63 s)
 (10/15) ../../tools/modulelint/modulelint.py:DockerfileSanitize.test_com_red_hat_component_label_exists: PASS (9.75 s)
 (11/15) ../../tools/modulelint/modulelint.py:DockerfileSanitize.test_iok8s_description_exists: PASS (6.16 s)
 (12/15) ../../tools/modulelint/modulelint.py:DockerfileSanitize.test_io_openshift_expose_services_exists: PASS (10.44 s)
 (13/15) ../../tools/modulelint/modulelint.py:DockerfileSanitize.test_io_openshift_tags_exists: PASS (4.09 s)
 (14/15) ../../tools/modulelint/modulelint.py:DockerfileLinterInContainer.test_docker_nodocs: PASS (28.34 s)
 (15/15) ../../tools/modulelint/modulelint.py:DockerfileLinterInContainer.test_docker_clean_all: PASS (17.21 s)
RESULTS    : PASS 15 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 165.51 s
JOB HTML   : /root/avocado/job-results/job-2017-08-29T22.04-8717556/results.html
$ 

```