### PR TITLE
Fixing CI tests. DockerLint in two classes and rpmvalidation logs problems

### DIFF
--- a/tools/modulelint.py
+++ b/tools/modulelint.py
@@ -28,37 +28,69 @@ from moduleframework import dockerlinter
 from moduleframework.avocado_testers import container_avocado_test
 
 
-class DockerfileLinter(module_framework.AvocadoTest):
+class DockerfileSanitize(container_avocado_test.ContainerAvocadoTest):
     """
     :avocado: enable
 
     """
 
-    dp = None
+    dp = dockerlinter.DockerfileLinter(os.path.join(os.getcwd(), ".."))
 
-    def setUp(self):
-        # it is not intended just for docker, but just docker packages are
-        # actually properly signed
-        self.dp = dockerlinter.DockerfileLinter(os.path.join(os.getcwd(), ".."))
-        if self.dp.dockerfile is None:
-            self.skip()
-
-    def testDockerFromBaseruntime(self):
+    def test_docker_from_baseruntime(self):
         self.assertTrue(self.dp.check_baseruntime())
 
-    def testDockerNodocs(self):
+    def test_architecture_in_env_and_label_exists(self):
+        self.assertTrue(self.dp.get_docker_specific_env("ARCH="))
+        self.assertTrue(self.dp.get_specific_label("architecture"))
+
+    def test_name_in_env_and_label_exists(self):
+        self.assertTrue(self.dp.get_docker_specific_env("NAME="))
+        self.assertTrue(self.dp.get_specific_label("name"))
+
+    def test_release_label_exists(self):
+        self.assertTrue(self.dp.get_specific_label("release"))
+
+    def test_version_label_exists(self):
+        self.assertTrue(self.dp.get_specific_label("version"))
+
+    def test_com_red_hat_component_label_exists(self):
+        self.assertTrue(self.dp.get_specific_label("com.redhat.component"))
+
+    def test_iok8s_description_exists(self):
+        self.assertTrue(self.dp.get_specific_label("io.k8s.description"))
+
+    def test_io_openshift_expose_services_exists(self):
+        label_io_openshift = "io.openshift.expose-services"
+        exposes = self.dp.get_docker_expose()
+        label_list = self.dp.get_docker_labels()
+        self.assertTrue(label_list[label_io_openshift])
+        for exp in exposes:
+            self.assertTrue("%s" % exp in label_list[label_io_openshift])
+
+    def test_io_openshift_tags_exists(self):
+        label_list = self.dp.get_docker_labels()
+        self.assertTrue("io.openshift.tags" in label_list)
+
+
+class DockerfileLinterInContainer(container_avocado_test.ContainerAvocadoTest):
+    """
+    :avocado: enable
+
+    """
+
+    def test_docker_nodocs(self):
         self.start()
-        installed_pkgs = self.run("rpm -qa --qf '%{{NAME}}\n'", ignore_status=True).stdout
+        installed_pkgs = self.run("rpm -qa --qf '%{{NAME}}\n'", verbose=False).stdout
         # This returns a list of packages defined in config.yaml for testing
         # e.g. ["bash", "rpm", "memcached"] in case of memcached
         pkgs = self.backend.getPackageList()
-        for pkg in installed_pkgs.split('\n'):
-            if pkg in pkgs:
-                all_docs = self.run("rpm -qd %s" % pkg).stdout
-                for doc in all_docs.strip().split('\n'):
-                    self.assertNotEqual(0, self.run("test -e %s" % doc, ignore_status=True).exit_status)
+        list_pkg = [pkg for pkg in installed_pkgs.split('\n') if pkg in pkgs]
+        for pkg in list_pkg:
+            all_docs = self.run("rpm -qd %s" % pkg, verbose=False).stdout
+            for doc in all_docs.strip().split('\n'):
+                self.assertNotEqual(0, self.run("test -e %s" % doc, ignore_status=True).exit_status)
 
-    def testDockerCleanAll(self):
+    def test_docker_clean_all(self):
         self.start()
         pkg_mgr = "yum"
         # Detect distro in image
@@ -70,38 +102,6 @@ class DockerfileLinter(module_framework.AvocadoTest):
         ret = self.run("ls /var/cache/%s/*.solv" % pkg_mgr, ignore_status=True)
         self.assertNotEqual(0, ret.exit_status)
         self.assertEqual("", ret.stdout.strip())
-
-    def testArchitectureInEnvAndLabelExists(self):
-        self.assertTrue(self.dp.get_docker_specific_env("ARCH="))
-        self.assertTrue(self.dp.get_specific_label("architecture"))
-
-    def testNameInEnvAndLabelExists(self):
-        self.assertTrue(self.dp.get_docker_specific_env("NAME="))
-        self.assertTrue(self.dp.get_specific_label("name"))
-
-    def testReleaseLabelExists(self):
-        self.assertTrue(self.dp.get_specific_label("release"))
-
-    def testVersionLabelExists(self):
-        self.assertTrue(self.dp.get_specific_label("version"))
-
-    def testComRedHatComponentLabelExists(self):
-        self.assertTrue(self.dp.get_specific_label("com.redhat.component"))
-
-    def testIok8sDescriptionExists(self):
-        self.assertTrue(self.dp.get_specific_label("io.k8s.description"))
-
-    def testIoOpenshiftExposeServicesExists(self):
-        label_io_openshift = "io.openshift.expose-services"
-        exposes = self.dp.get_docker_expose()
-        label_list = self.dp.get_docker_labels()
-        self.assertTrue(label_list[label_io_openshift])
-        for exp in exposes:
-            self.assertTrue("%s" % exp in label_list[label_io_openshift])
-
-    def testIoOpenShiftTagsExists(self):
-        label_list = self.dp.get_docker_labels()
-        self.assertTrue("io.openshift.tags" in label_list)
 
 
 class DockerLint(container_avocado_test.ContainerAvocadoTest):

--- a/tools/modulelint/rpmvalidation.py
+++ b/tools/modulelint/rpmvalidation.py
@@ -96,11 +96,11 @@ class rpmvalidation(module_framework.AvocadoTest):
         return False
 
     def test(self):
-        allpackages = filter(bool, self.run("rpm -qa").stdout.split("\n"))
+        allpackages = filter(bool, self.run("rpm -qa", verbose=False).stdout.split("\n"))
         common.print_debug(allpackages)
         for package in allpackages:
             if 'filesystem' in package:
                 continue
-            for package_file in filter(bool, self.run("rpm -ql %s" % package).stdout.split("\n")):
+            for package_file in filter(bool, self.run("rpm -ql %s" % package, verbose=False).stdout.split("\n")):
                 if not self._compare_fhs(package_file):
                     self.fail("(%s): File [%s] violates the FHS." % (package, package_file))

--- a/tools/modulelint/rpmvalidation.py
+++ b/tools/modulelint/rpmvalidation.py
@@ -88,7 +88,9 @@ class rpmvalidation(module_framework.AvocadoTest):
             return True
         for path in self.fhs_base_paths:
             if filepath.startswith(path):
-                self.log.info("%s starts with FSH %s" % (filepath, path))
+                # Log is not needed I guess. It causes troubles in Travis CI.
+                # log is pretty huge.
+                # self.log.debug("%s starts with FSH %s" % (filepath, path))
                 return True
         self.log.info("%s not found in %s" % (filepath, self.fhs_base_paths))
         return False


### PR DESCRIPTION
This PR fixes troubles in Dockerlint.py.

The Docker tests are separated into 2 classes.
* DockerfileSanitize only sanitize Dockerfile
* DockerfileSanitizeInHost sanitize Dockerfile things inside alone container.

Tests for `make check-rpm` are mentioned here

```
22:00 $ sudo make check-rpm 
[sudo] password for phracek: 
MODULE=nspawn mtf-env-set
name of CHROOT directory:
/opt/chroot_bash_1504036867.528037
Disabling selinux
Disabling selinux
MODULE=nspawn CONFIG=./fullconfig.yaml avocado run ../../tools/modulelint/modulelint.py
JOB ID     : 6650eaf4b0e0ac24ad19265b9ea377c87a3ececc
JOB LOG    : /root/avocado/job-results/job-2017-08-29T22.01-6650eaf/job.log
 (01/15) ../../tools/modulelint/modulelint.py:DockerLint.testBasic: SKIP
 (02/15) ../../tools/modulelint/modulelint.py:DockerLint.testContainerIsRunning: SKIP
 (03/15) ../../tools/modulelint/modulelint.py:DockerLint.testLabels: SKIP
 (04/15) ../../tools/modulelint/modulelint.py:ModuleLintPackagesCheck.test: PASS (144.70 s)
 (05/15) ../../tools/modulelint/modulelint.py:DockerfileSanitize.test_docker_from_baseruntime: SKIP
 (06/15) ../../tools/modulelint/modulelint.py:DockerfileSanitize.test_architecture_in_env_and_label_exists: SKIP
 (07/15) ../../tools/modulelint/modulelint.py:DockerfileSanitize.test_name_in_env_and_label_exists: SKIP
 (08/15) ../../tools/modulelint/modulelint.py:DockerfileSanitize.test_release_label_exists: SKIP
 (09/15) ../../tools/modulelint/modulelint.py:DockerfileSanitize.test_version_label_exists: SKIP
 (10/15) ../../tools/modulelint/modulelint.py:DockerfileSanitize.test_com_red_hat_component_label_exists: SKIP
 (11/15) ../../tools/modulelint/modulelint.py:DockerfileSanitize.test_iok8s_description_exists: SKIP
 (12/15) ../../tools/modulelint/modulelint.py:DockerfileSanitize.test_io_openshift_expose_services_exists: SKIP
 (13/15) ../../tools/modulelint/modulelint.py:DockerfileSanitize.test_io_openshift_tags_exists: SKIP
 (14/15) ../../tools/modulelint/modulelint.py:DockerfileLinterInContainer.test_docker_nodocs: SKIP
 (15/15) ../../tools/modulelint/modulelint.py:DockerfileLinterInContainer.test_docker_clean_all: SKIP
RESULTS    : PASS 1 | ERROR 0 | FAIL 0 | SKIP 14 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 163.61 s
JOB HTML   : /root/avocado/job-results/job-2017-08-29T22.01-6650eaf/results.html
```
Tests related to `make check-docker`
```
$ sudo make check-docker
MODULE=docker mtf-env-set
MODULE=docker CONFIG=./fullconfig.yaml avocado run ../../tools/modulelint/modulelint.py
JOB ID     : 87175563eb86074d8a171db6e06f3b7de37f3077
JOB LOG    : /root/avocado/job-results/job-2017-08-29T22.04-8717556/job.log
 (01/15) ../../tools/modulelint/modulelint.py:DockerLint.testBasic: PASS (17.46 s)
 (02/15) ../../tools/modulelint/modulelint.py:DockerLint.testContainerIsRunning: PASS (18.51 s)
 (03/15) ../../tools/modulelint/modulelint.py:DockerLint.testLabels: PASS (8.74 s)
 (04/15) ../../tools/modulelint/modulelint.py:ModuleLintPackagesCheck.test: PASS (17.48 s)
 (05/15) ../../tools/modulelint/modulelint.py:DockerfileSanitize.test_docker_from_baseruntime: PASS (5.81 s)
 (06/15) ../../tools/modulelint/modulelint.py:DockerfileSanitize.test_architecture_in_env_and_label_exists: PASS (4.24 s)
 (07/15) ../../tools/modulelint/modulelint.py:DockerfileSanitize.test_name_in_env_and_label_exists: PASS (4.20 s)
 (08/15) ../../tools/modulelint/modulelint.py:DockerfileSanitize.test_release_label_exists: PASS (3.84 s)
 (09/15) ../../tools/modulelint/modulelint.py:DockerfileSanitize.test_version_label_exists: PASS (5.63 s)
 (10/15) ../../tools/modulelint/modulelint.py:DockerfileSanitize.test_com_red_hat_component_label_exists: PASS (9.75 s)
 (11/15) ../../tools/modulelint/modulelint.py:DockerfileSanitize.test_iok8s_description_exists: PASS (6.16 s)
 (12/15) ../../tools/modulelint/modulelint.py:DockerfileSanitize.test_io_openshift_expose_services_exists: PASS (10.44 s)
 (13/15) ../../tools/modulelint/modulelint.py:DockerfileSanitize.test_io_openshift_tags_exists: PASS (4.09 s)
 (14/15) ../../tools/modulelint/modulelint.py:DockerfileLinterInContainer.test_docker_nodocs: PASS (28.34 s)
 (15/15) ../../tools/modulelint/modulelint.py:DockerfileLinterInContainer.test_docker_clean_all: PASS (17.21 s)
RESULTS    : PASS 15 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 165.51 s
JOB HTML   : /root/avocado/job-results/job-2017-08-29T22.04-8717556/results.html
$ 

```