### PR TITLE
examples for pytest, unittest, nosetest - simple examples

### DIFF
--- a/examples/alternative_frameworks/Makefile
+++ b/examples/alternative_frameworks/Makefile
@@ -1,0 +1,16 @@
+export MTF_REMOTE_REPOS=yes
+export DEBUG=yes
+export MODULE=docker
+
+prepare-docker:
+	 dnf -y install pytest python2-case
+	 mtf-env-set
+
+check-nosetest: prepare-docker
+	nosetests
+
+check-unittest: prepare-docker
+	python -m unittest example_unittest
+
+check-pytest: prepare-docker
+	pytest -q example_pytest.py

--- a/examples/alternative_frameworks/example_pytest.py
+++ b/examples/alternative_frameworks/example_pytest.py
@@ -1,0 +1,11 @@
+import pytest
+from moduleframework import module_framework
+
+
+def test_simple():
+    backend, moduletype = module_framework.get_backend()
+    backend.setUp()
+    backend.start()
+    assert "bin" in backend.run("ls /").stdout
+    backend.tearDown()
+

--- a/examples/alternative_frameworks/example_unittest.py
+++ b/examples/alternative_frameworks/example_unittest.py
@@ -1,0 +1,18 @@
+import unittest
+from moduleframework import module_framework
+
+class TestSimple(unittest.TestCase):
+
+    def setUp(self):
+        self.backend, self.moduletype = module_framework.get_backend()
+        self.backend.setUp()
+        self.backend.start()
+
+    def tearDown(self):
+        self.backend.tearDown()
+
+    def test_simple(self):
+        self.assertIn("bin", self.backend.run("ls /").stdout)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/examples/alternative_frameworks/test_nosetest.py
+++ b/examples/alternative_frameworks/test_nosetest.py
@@ -1,0 +1,21 @@
+from moduleframework import module_framework
+
+
+def test_simple():
+    backend, moduletype = module_framework.get_backend()
+    backend.setUp()
+    backend.start()
+    assert "bin" in backend.run("ls /").stdout
+    backend.tearDown()
+
+class TestExampleTwo:
+    def setUp(self):
+        self.backend, self.moduletype = module_framework.get_backend()
+        self.backend.setUp()
+        self.backend.start()
+
+    def test_simpleinclass(self):
+        assert "bin" in self.backend.run("ls /").stdout
+
+    def tearDown(self):
+        self.backend.tearDown()


### PR DESCRIPTION
For people who are interested to use alternative framework than avocado, there are  some examples for

- nosetest
- py.test
- unittest

just simple one. when someone ask, there could be added some derived classes based on these frameworks, to avoid explicit calls for backends function especially in setUp or tearDown.
Especially @psklenar were interested how to use it.

you can run it via `Makefile`
there are targets for these framworks `check-*` sections in `Makefile`