### PR TITLE
remove python docker requirements, cause trouble in taskotron for shell test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 PyYAML
 avocado-framework
 avocado-framework-plugin-result-html
-docker
 dockerfile-parse
 modulemd
 netifaces


### PR DESCRIPTION
```
15:00:55 DEBUG| [stderr] Traceback (most recent call last):
15:00:55 DEBUG| [stderr]   File "/usr/bin/mtf-cmd", line 6, in <module>
15:00:55 DEBUG| [stderr]     from pkg_resources import load_entry_point
15:00:55 DEBUG| [stderr]   File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 3038, in <module>
15:00:55 DEBUG| [stderr]     @_call_aside
15:00:55 DEBUG| [stderr]   File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 3022, in _call_aside
15:00:55 DEBUG| [stderr]     f(*args, **kwargs)
15:00:55 DEBUG| [stderr]   File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 3051, in _initialize_master_working_set
15:00:55 DEBUG| [stderr]     working_set = WorkingSet._build_master()
15:00:55 DEBUG| [stderr]   File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 657, in _build_master
15:00:55 DEBUG| [stderr]     ws.require(__requires__)
15:00:55 DEBUG| [stderr]   File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 971, in require
15:00:55 DEBUG| [stderr]     needed = self.resolve(parse_requirements(requirements))
15:00:55 DEBUG| [stderr]   File "/usr/lib/python2.7/site-packages/pkg_resources/__init__.py", line 857, in resolve
15:00:55 DEBUG| [stderr]     raise DistributionNotFound(req, requirers)
15:00:55 DEBUG| [stderr] pkg_resources.DistributionNotFound: The 'docker' distribution was not found and is required by meta-test-family
```