### PR TITLE
WIP: Modulelint filtering

### DIFF
--- a/moduleframework/tools/__init__.py
+++ b/moduleframework/tools/__init__.py
@@ -28,6 +28,7 @@ from moduleframework import module_framework
 class Basic(module_framework.AvocadoTest):
     """
     :avocado: enable
+    :avocado: tags=docker,fedora,rhel,tier1
     """
 
     def test(self):

--- a/moduleframework/tools/check_compose.py
+++ b/moduleframework/tools/check_compose.py
@@ -33,6 +33,7 @@ class ComposeTest(module_framework.NspawnAvocadoTest):
     Validate overall module compose.
 
     :avocado: enable
+    :avocado: tags=docker,fedora,rhel,tier1,slow
     """
 
     def test_component_profile_installability(self):

--- a/moduleframework/tools/dockerlint.py
+++ b/moduleframework/tools/dockerlint.py
@@ -32,6 +32,7 @@ from moduleframework.common import get_docker_file
 class DockerFileLinter(module_framework.AvocadoTest):
     """
     :avocado: enable
+    :avocado: tags=docker,fedora,rhel,tier1
 
     """
 
@@ -100,6 +101,7 @@ class DockerFileLinter(module_framework.AvocadoTest):
 class DockerLint(container_avocado_test.ContainerAvocadoTest):
     """
     :avocado: enable
+    :avocado: tags=docker,fedora,rhel,tier1
     """
 
     def testLabels(self):

--- a/moduleframework/tools/helpmd_lint.py
+++ b/moduleframework/tools/helpmd_lint.py
@@ -32,6 +32,7 @@ from moduleframework.common import get_docker_file
 class HelpMDLinter(module_framework.AvocadoTest):
     """
     :avocado: enable
+    :avocado: tags=docker,fedora,rhel,optional
 
     """
 
@@ -57,11 +58,15 @@ class HelpMDLinter(module_framework.AvocadoTest):
         container_name = self.dp.get_docker_specific_env("NAME=")
         if container_name:
             self.assertTrue(self.helpmd.get_image_name(container_name[0].split('=')[1]))
+        else:
+            self.cancel()
 
     def test_helpmd_maintainer_name(self):
         maintainer_name = self.dp.get_specific_label("maintainer")
         if maintainer_name:
             self.assertTrue(self.helpmd.get_maintainer_name(maintainer_name[0]))
+        else:
+            self.cancel()
 
     def test_helpmd_name(self):
         self.assertTrue(self.helpmd.get_tag("NAME"))
@@ -82,3 +87,5 @@ class HelpMDLinter(module_framework.AvocadoTest):
     def test_helpmd_security_implications(self):
         if self.dp.get_docker_expose():
             self.assertTrue(self.helpmd.get_tag("SECURITY IMPLICATIONS"))
+        else:
+            self.cancel()

--- a/moduleframework/tools/modulelint.py
+++ b/moduleframework/tools/modulelint.py
@@ -27,8 +27,8 @@ from moduleframework import module_framework
 
 class ModuleLintSigning(module_framework.AvocadoTest):
     """
-    :avocado: disable
-    :avocado: tags=WIP
+    :avocado: enable
+    :avocado: tags=docker,fedora,rhel,tier1,WIP
     """
 
     def setUp(self):
@@ -48,12 +48,16 @@ class ModuleLintSigning(module_framework.AvocadoTest):
         for package in [x.strip() for x in allpackages.split('\n')]:
             pinfo = package.split(', ')
             if len(pinfo) == 3:
-                self.assertIn(KEY, pinfo[2])
+                if KEY in pinfo[2]:
+                    self.assertTrue(True,msg="%s in %s" % (KEY,pinfo[2]))
+                else:
+                    self.log.warn("Package sign verify failed: %s not in %s" % (KEY,pinfo[2]))
 
 
 class ModuleLintPackagesCheck(module_framework.AvocadoTest):
     """
     :avocado: enable
+    :avocado: tags=docker,fedora,rhel,tier1
     """
 
     def test(self):

--- a/moduleframework/tools/rpmvalidation.py
+++ b/moduleframework/tools/rpmvalidation.py
@@ -35,6 +35,7 @@ class rpmvalidation(module_framework.AvocadoTest):
     http://refspecs.linuxfoundation.org/FHS_3.0/fhs/index.html
     
     :avocado: enable
+    :avocado: tags=docker,fedora,rhel,tier1
     """
     fhs_base_paths_workaound = [
         '/var/kerberos',

--- a/tools/mtf
+++ b/tools/mtf
@@ -1,9 +1,11 @@
 #!/bin/bash
 
+AVOCADO_CMD="avocado"
 SITE_LIB=$(python -c "import moduleframework, os; print os.path.dirname(moduleframework.__file__)")
 MTF_TOOLS="tools"
-JSON_LOG=$(mktemp)
-AVOCADO_ARGS="--json $JSON_LOG"
+AVOCADO_ARGS=""
+ACTION="run"
+TAGS="--filter-by-tags-include-empty"
 
 function print_help {
   cat <<EOF
@@ -13,8 +15,39 @@ positional arguments:
   AVOCADO_ARGS        test files and any arguments that "avocado run" accepts
 
 optional arguments:
+  -a, --action        run selected avocado command (DEFAULT: run)
   -h, --help          show this help message and exit
   -l, --linters       also run default linter tests included in MTF
+  -t, --tags T1,-T2   set test filtering based on tags, use --taglist for help ()
+  --taglist           oficially supported tag list (you can use whatever you want, this is list oficially used)
+                      for more info look at:
+                      http://avocado-framework.readthedocs.io/en/55.0/Loaders.html#filtering-tests-by-tags
+
+EOF
+}
+
+function print_tags {
+  cat <<EOF
+list of well known tags:
+  test environments:
+    rhel     - working on RedHat Enterprise Linux and CentOs
+    fedora   - working on Fedora
+    docker   - working on Docker
+
+  test categorization:
+    tier1    - basic qualification tests
+    tier2    - extended qualification tests
+    optional - could fail on some variants (not everything is supported)
+    slow     - slow testcases, longer than expected (hrs, or days)
+    WIP      - work in progress tests, could be bad, failing or under developlment
+
+In tests use docs string like (to allow run test on fedora, rhel and docker env and it is tier1 test).
+It is possible to use tags in doc string in class or in class method.
+Methods tags are ingerited from class tags
+Like:
+      """
+      :avocado: tags=fedora,rhel,docker,tier1
+      """
 EOF
 }
 
@@ -27,6 +60,18 @@ while [[ $# -gt 0 ]]; do
       -l|--linters)
         AVOCADO_ARGS="$AVOCADO_ARGS $SITE_LIB/$MTF_TOOLS/*.py"
       ;;
+      --taglist)
+        print_tags
+        exit 0
+      ;;
+      -a|--action)
+        shift
+        ACTION="$1"
+      ;;
+      -t|--tags)
+        shift
+        TAGS="$TAGS --filter-by-tags=$1"
+      ;;
       *)
         AVOCADO_ARGS="$AVOCADO_ARGS $1"
       ;;
@@ -34,9 +79,17 @@ while [[ $# -gt 0 ]]; do
   shift
 done
 
+# used by mtf-log-parser
+test "$ACTION" = "run" && JSON_LOG=$(mktemp)
+test "$ACTION" = "run" && AVOCADO_ARGS="$AVOCADO_ARGS --json $JSON_LOG"
+
+# append filtering
+test -n "$TAGS"        && AVOCADO_ARGS="$AVOCADO_ARGS $TAGS"
+
 # preserve exist status, mtf command should finish same as testing.
-avocado run $AVOCADO_ARGS
+echo "RUNNING: $AVOCADO_CMD $ACTION $AVOCADO_ARGS"
+$AVOCADO_CMD "$ACTION" $AVOCADO_ARGS
 EXIT_STATUS=$?
-mtf-log-parser $JSON_LOG
-rm -f $JSON_LOG
+test "$ACTION" = "run" && mtf-log-parser $JSON_LOG
+test "$ACTION" = "run" && rm -f $JSON_LOG
 exit $EXIT_STATUS


### PR DESCRIPTION
basic example how test filtering can be done with tooling (mtf tool)
see examples:
* list of tests and cout them:  `mtf -a list -l  -t tier1,fedora | wc -l`
* run tests: `mtf -l  -t fedora,tier1,optional` (it is empty, there is no testcase with tier1 and optional together)
* run just optional tests (tier1 exclueded): `mtf -l  -t optional,-tier1 `
* run all test (backward compatible): `mtf -l`
