### PR TITLE
testing container in OpenShift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ travis:
 
 clean:
 	pip uninstall .
-	git clean -fd
+	#git clean -fd
 	rm -rf build/html
 
 install: clean

--- a/docs/user_guide/environment_setup.rst
+++ b/docs/user_guide/environment_setup.rst
@@ -24,7 +24,7 @@ Manual Setup
 **OpenShift**
 
  - Install OpenShift if not installed and if environment variable ``OPENSHIFT_LOCAL`` is specified.
- - if ``OPENSHIFT_LOCAL`` variable is specified, the it starts an OpenShift by command ``oc cluster up`` or stops it by command ``oc cluster down``.
+ - if ``OPENSHIFT_LOCAL`` variable is specified, then it starts an OpenShift by command ``oc cluster up`` or stops it by command ``oc cluster down``.
 
 Automated Setup
 ~~~~~~~~~~~~~~~

--- a/docs/user_guide/environment_setup.rst
+++ b/docs/user_guide/environment_setup.rst
@@ -21,13 +21,18 @@ Manual Setup
 
  - No any configuration needed
 
+**OpenShift**
+
+ - Install OpenShift if not installed and if environment variable ``OPENSHIFT_LOCAL`` is specified.
+ - if ``OPENSHIFT_LOCAL`` variable is specified, the it starts an OpenShift by command ``oc cluster up`` or stops it by command ``oc cluster down``.
+
 Automated Setup
 ~~~~~~~~~~~~~~~
 
 The environment configuration scripts should be executed in the same directory where the tests are, otherwise the environment variable **CONFIG** should be set.
 
   - to setup environment run ``MODULE=docker mtf-env-set``
-  - to execute tests run ``MODULE=docker avocado run your.test.py``
+  - to execute tests run ``MODULE=docker mtf your.test.py``
   - to cleanup environment ``MODULE=docker mtf-env-clean``
 
 Test Creation

--- a/docs/user_guide/environment_variables.rst
+++ b/docs/user_guide/environment_variables.rst
@@ -25,10 +25,10 @@ Environment variables allow to overwrite some values of a module configuration f
 - **MTF_REMOTE_REPOS=yes** disables downloading of Koji packages and creating a local repo, and speeds up test execution.
 - **MTF_DISABLE_MODULE=yes** disables module handling to use nonmodular test mode (see `multihost tests`_ as an example).
 - **DOCKERFILE="<path_to_dockerfile"** overwrites the location of a Dockerfile.
-- **OPENSHIFT_LOCAL** enables installing ``origin`` and ``origin-clients`` on local machine
-- **OPENSHIFT_IP** uses this IP address for connecting to an OpenShift environment.
-- **OPENSHIFT_USER** uses this ``USER`` name for login to an OpenShift environment.
-- **OPENSHIFT_PWD** uses this ``PWD`` name for login to an OpenShift environment.
+- **OPENSHIFT_LOCAL=yes** enables installing ``origin`` and ``origin-clients`` on local machine
+- **OPENSHIFT_IP=openshift_ip_address** uses this IP address for connecting to an OpenShift environment.
+- **OPENSHIFT_USER=developer** uses this ``USER`` name for login to an OpenShift environment.
+- **OPENSHIFT_PASSWORD=developer** uses this ``PASSWORD`` name for login to an OpenShift environment.
 
 .. _multihost tests: https://github.com/fedora-modularity/meta-test-family/tree/devel/examples/multios_testing
 

--- a/docs/user_guide/environment_variables.rst
+++ b/docs/user_guide/environment_variables.rst
@@ -25,6 +25,10 @@ Environment variables allow to overwrite some values of a module configuration f
 - **MTF_REMOTE_REPOS=yes** disables downloading of Koji packages and creating a local repo, and speeds up test execution.
 - **MTF_DISABLE_MODULE=yes** disables module handling to use nonmodular test mode (see `multihost tests`_ as an example).
 - **DOCKERFILE="<path_to_dockerfile"** overwrites the location of a Dockerfile.
+- **OPENSHIFT_LOCAL** enables installing ``origin`` and ``origin-clients`` on local machine
+- **OPENSHIFT_IP** uses this IP address for connecting to an OpenShift environment.
+- **OPENSHIFT_USER** uses this ``USER`` name for login to an OpenShift environment.
+- **OPENSHIFT_PWD** uses this ``PWD`` name for login to an OpenShift environment.
 
 .. _multihost tests: https://github.com/fedora-modularity/meta-test-family/tree/devel/examples/multios_testing
 

--- a/docs/user_guide/index.rst
+++ b/docs/user_guide/index.rst
@@ -54,6 +54,7 @@ User Guide
     test: build
         cd tests; MODULE=docker MODULEMD=$(MODULEMDURL) URL="docker=$(IMAGE_NAME)" make all
         cd tests; MODULE=nspawn MODULEMD=$(MODULEMDURL) make all
+        cd tests; MODULE=openshift OPENSHIFT_IP="127.0.0.1" OPENSHIFT_USER="developer" OPENSHIFT_PASSWORD="developer" make all
 
 7. `Prepare the environment`_ to run tests in.
 
@@ -71,14 +72,14 @@ User Guide
  .. code-block:: shell
 
     #run Python tests from the tests/ directory
-    $ sudo MODULE=docker avocado run ./*.py
+    $ sudo MODULE=docker mtf ./*.py
 
  or
 
  .. code-block:: shell
 
     #run Bash tests from the tests/ directory
-    $ sudo MODULE=docker avocado run ./*.sh
+    $ sudo MODULE=docker mtf ./*.sh
 
 
 9. `Clean up the environment`_ after test execution.

--- a/moduleframework/avocado_testers/avocado_test.py
+++ b/moduleframework/avocado_testers/avocado_test.py
@@ -34,6 +34,7 @@ from moduleframework.common import *
 from moduleframework.helpers.container_helper import ContainerHelper
 from moduleframework.helpers.nspawn_helper import NspawnHelper
 from moduleframework.helpers.rpm_helper import RpmHelper
+from moduleframework.helpers.openshift_helper import OpenShiftHelper
 
 
 # INTERFACE CLASS FOR GENERAL TESTS OF MODULES
@@ -292,6 +293,9 @@ def get_backend():
         return RpmHelper()
     elif parent == 'nspawn':
         return NspawnHelper()
+    elif parent == 'openshift':
+        return OpenShiftHelper()
+
 
 # To keep backward compatibility. This method could be used by pure avocado tests and is already used
 get_correct_backend = get_backend

--- a/moduleframework/avocado_testers/openshift_avocado_test.py
+++ b/moduleframework/avocado_testers/openshift_avocado_test.py
@@ -27,7 +27,7 @@ from moduleframework.common import get_module_type_base
 # INTERFACE CLASSES FOR SPECIFIC MODULE TESTS
 class OpenShiftAvocadoTest(AvocadoTest):
     """
-    Class for writing tests specific just for DOCKER
+    Class for writing tests specific just for OpenShift
     derived from AvocadoTest class.
 
     :avocado: disable

--- a/moduleframework/avocado_testers/openshift_avocado_test.py
+++ b/moduleframework/avocado_testers/openshift_avocado_test.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+#
+# This Modularity Testing Framework helps you to write tests for modules
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# he Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Authors: Petr Hracek <phracek@redhat.com>
+#
+
+from moduleframework.module_framework import AvocadoTest
+from moduleframework.common import get_module_type_base
+
+
+# INTERFACE CLASSES FOR SPECIFIC MODULE TESTS
+class OpenShiftAvocadoTest(AvocadoTest):
+    """
+    Class for writing tests specific just for DOCKER
+    derived from AvocadoTest class.
+
+    :avocado: disable
+    """
+
+    def setUp(self):
+        if get_module_type_base() != "openshift":
+            self.cancel("OpenShift specific test")
+        super(OpenShiftAvocadoTest, self).setUp()
+
+    def checkLabel(self, key, value):
+        """
+        check label of docker image, expect key value (could be read from config file)
+
+        :param key: str
+        :param value: str
+        :return: bool
+        """
+        if key in self.backend.containerInfo['Labels'] and (
+                    value in self.backend.containerInfo['Labels'][key]):
+            return True
+        return False
+
+

--- a/moduleframework/avocado_testers/openshift_avocado_test.py
+++ b/moduleframework/avocado_testers/openshift_avocado_test.py
@@ -37,18 +37,3 @@ class OpenShiftAvocadoTest(AvocadoTest):
         if get_module_type_base() != "openshift":
             self.cancel("OpenShift specific test")
         super(OpenShiftAvocadoTest, self).setUp()
-
-    def checkLabel(self, key, value):
-        """
-        check label of docker image, expect key value (could be read from config file)
-
-        :param key: str
-        :param value: str
-        :return: bool
-        """
-        if key in self.backend.containerInfo['Labels'] and (
-                    value in self.backend.containerInfo['Labels'][key]):
-            return True
-        return False
-
-

--- a/moduleframework/common.py
+++ b/moduleframework/common.py
@@ -504,7 +504,6 @@ class CommonFunctions(object):
             self.modulemdConf = link
         return link
 
-
     def getIPaddr(self):
         """
         Return protocol (IP or IPv6) address on a guest machine.
@@ -514,7 +513,6 @@ class CommonFunctions(object):
 
         :return: str
         """
-        print_info(os.environ.get('MODULE'))
         if 'openshift' == os.environ.get('MODULE'):
             return trans_dict['GUESTIPADDR']
         return self.ipaddr

--- a/moduleframework/common.py
+++ b/moduleframework/common.py
@@ -504,6 +504,7 @@ class CommonFunctions(object):
             self.modulemdConf = link
         return link
 
+
     def getIPaddr(self):
         """
         Return protocol (IP or IPv6) address on a guest machine.
@@ -513,6 +514,9 @@ class CommonFunctions(object):
 
         :return: str
         """
+        print_info(os.environ.get('MODULE'))
+        if 'openshift' == os.environ.get('MODULE'):
+            return trans_dict['GUESTIPADDR']
         return self.ipaddr
 
     def _callSetupFromConfig(self):
@@ -641,7 +645,7 @@ class CommonFunctions(object):
         if src is not dest:
             self.run("cp -rf %s %s" % (src, dest))
 
-    def run_script(self,filename, *args, **kwargs):
+    def run_script(self, filename, *args, **kwargs):
         """
         run script or binary inside module
         :param filename: filename to copy to module
@@ -656,6 +660,7 @@ class CommonFunctions(object):
         if args:
             parameters = " " + " ".join(args)
         return self.run("bash " + dest + parameters, **kwargs)
+
 
 def get_config():
     """
@@ -697,8 +702,8 @@ def get_config():
                 raise ConfigExc("No module in yaml config defined")
             # copy rpm section to nspawn, in case not defined explicitly
             # make it backward compatible
-            if xcfg.get("module",{}).get("rpm") and not xcfg.get("module",{}).get("nspawn"):
-                xcfg["module"]["nspawn"] = copy.deepcopy(xcfg.get("module",{}).get("rpm"))
+            if xcfg.get("module", {}).get("rpm") and not xcfg.get("module", {}).get("nspawn"):
+                xcfg["module"]["nspawn"] = copy.deepcopy(xcfg.get("module", {}).get("rpm"))
             __persistent_config = xcfg
             return xcfg
         except IOError:
@@ -726,7 +731,7 @@ def get_backend_list():
 
     :return: list
     """
-    base_module_list = ["rpm", "nspawn", "docker"]
+    base_module_list = ["rpm", "nspawn", "docker", "openshift"]
     return base_module_list
 
 
@@ -757,7 +762,7 @@ def get_module_type_base():
     module_type = get_module_type()
     parent = module_type
     if module_type not in get_backend_list():
-        parent = get_config().get("module",{}).get(module_type, {}).get("parent")
+        parent = get_config().get("module", {}).get(module_type, {}).get("parent")
         if not parent:
             raise ModuleFrameworkException("Module (%s) does not provide parent backend parameter (there are: %s)" %
                                            (module_type, get_backend_list()))

--- a/moduleframework/common.py
+++ b/moduleframework/common.py
@@ -86,8 +86,10 @@ DEFAULTRETRYTIMEOUT = 30
 DEFAULTNSPAWNTIMEOUT = 10
 MODULE_DEFAULT_PROFILE="default"
 
+
 def generate_unique_name(size=10):
     return ''.join(random.choice(string.ascii_lowercase) for _ in range(size))
+
 
 def get_compose_url_modular_release():
     default_release = "27"
@@ -98,6 +100,7 @@ def get_compose_url_modular_release():
     base_url = "https://kojipkgs.fedoraproject.org/compose/latest-Fedora-Modular-{}/compose/Server/{}/os"
     compose_url = os.environ.get("MTF_COMPOSE_BASE") or base_url.format(release, ARCH)
     return compose_url
+
 
 def is_debug():
     """
@@ -115,6 +118,47 @@ def is_not_silent():
     :return: bool
     """
     return is_debug()
+
+
+def get_openshift_local():
+    """
+    Return the **OPENSHIFT_LOCAL** envvar.
+    :return: bool
+    """
+    return bool(os.environ.get('OPENSHIFT_LOCAL'))
+
+
+def get_openshift_ip():
+    """
+    Return the **OPENSHIFT_IP** envvar or None.
+    :return: OpenShift IP or None
+    """
+    try:
+        return os.environ.get('OPENSHIFT_IP')
+    except KeyError:
+        return None
+
+
+def get_openshift_user():
+    """
+    Return the **OPENSHIFT_USER** envvar or None.
+    :return: OpenShift User or None
+    """
+    try:
+        return os.environ.get('OPENSHIFT_USER')
+    except KeyError:
+        return None
+
+
+def get_openshift_passwd():
+    """
+    Return the **OPENSHIFT_PASSWORD** envvar or None.
+    :return: OpenShift password or None
+    """
+    try:
+        return os.environ.get('OPENSHIFT_PASSWORD')
+    except KeyError:
+        return None
 
 
 def print_info(*args):
@@ -178,6 +222,7 @@ def is_recursive_download():
     """
     return bool(os.environ.get("MTF_RECURSIVE_DOWNLOAD"))
 
+
 def get_if_do_cleanup():
     """
     Return the **MTF_DO_NOT_CLEANUP** envvar.
@@ -187,6 +232,7 @@ def get_if_do_cleanup():
     cleanup = os.environ.get('MTF_DO_NOT_CLEANUP')
     return not bool(cleanup)
 
+
 def get_if_reuse():
     """
         Return the **MTF_REUSE** envvar.
@@ -195,6 +241,7 @@ def get_if_reuse():
         """
     reuse = os.environ.get('MTF_REUSE')
     return bool(reuse)
+
 
 def get_if_remoterepos():
     """
@@ -223,8 +270,8 @@ def sanitize_text(text, replacement="_", invalid_chars=["/", ";", "&", ">", "<",
 
     invalid_chars=["/", ";", "&", ">", "<", "|"]
 
-    :param (str): text to sanitize
-    :param (str): replacement char, default: "_"
+    :param replacement: text to sanitize
+    :param invalid_chars: replacement char, default: "_"
     :return: str
     """
     for char in invalid_chars:
@@ -237,7 +284,7 @@ def sanitize_cmd(cmd):
     """
     Escape apostrophes in a command line.
 
-    :param (str): command to sanitize
+    :param cmd: command to sanitize
     :return: str
     """
     if '"' in cmd:
@@ -257,6 +304,7 @@ def translate_cmd(cmd, translation_dict=None):
             "in trans_dict are: %s. \nBAD COMMAND: %s"
             % (translation_dict, cmd))
     return formattedcommand
+
 
 def get_profile():
     """
@@ -340,9 +388,9 @@ class CommonFunctions(object):
         """
         # we have to copy object. because there is just one global object, to improve performance
         self.config = copy.deepcopy(get_config())
-        self.info = self.config.get("module",{}).get(get_module_type_base())
+        self.info = self.config.get("module", {}).get(get_module_type_base())
         # if there is inheritance join both dictionary
-        self.info.update(self.config.get("module",{}).get(get_module_type()))
+        self.info.update(self.config.get("module", {}).get(get_module_type()))
         if not self.info:
             raise ConfigExc("There is no section for (module: -> %s:) in the configuration file." %
                             get_module_type_base())
@@ -401,7 +449,7 @@ class CommonFunctions(object):
         """
         Run commands on a host.
 
-        :param (str): command to exectute
+        :param common: command to exectute
         ** kwargs: avocado process.run params like: shell, ignore_status, verbose
         :return: avocado.process.run
         """
@@ -451,15 +499,15 @@ class CommonFunctions(object):
             if 'packages' in self.config:
                 packages_rpm = self.config.get('packages',{}).get('rpms', [])
                 packages_profiles = []
-                for profile_in_conf in self.config.get('packages',{}).get('profiles',[]):
+                for profile_in_conf in self.config.get('packages', {}).get('profiles', []):
                     packages_profiles += mddata['data']['profiles'][profile_in_conf]['rpms']
                 package_list += packages_rpm + packages_profiles
             if get_if_install_default_profile():
-                profile_append = mddata.get('data',{})\
-                    .get('profiles',{}).get(MODULE_DEFAULT_PROFILE,{}).get('rpms',[])
+                profile_append = mddata.get('data', {})\
+                    .get('profiles', {}).get(MODULE_DEFAULT_PROFILE, {}).get('rpms', [])
                 package_list += profile_append
         else:
-            package_list += mddata['data']['profiles'][profile].get('rpms',[])
+            package_list += mddata['data']['profiles'][profile].get('rpms', [])
         print_info("PCKGs to install inside module:", package_list)
         return package_list
 
@@ -513,8 +561,6 @@ class CommonFunctions(object):
 
         :return: str
         """
-        if 'openshift' == os.environ.get('MODULE'):
-            return trans_dict['GUESTIPADDR']
         return self.ipaddr
 
     def _callSetupFromConfig(self):

--- a/moduleframework/environment_prepare/openshift_prepare.py
+++ b/moduleframework/environment_prepare/openshift_prepare.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+#
+# Meta test family (MTF) is a tool to test components of a modular Fedora:
+# https://docs.pagure.org/modularity/
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# he Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Authors: Petr Hracek <phracek@redhat.com>
+#
+
+"""
+module for OpenShift environment setup and cleanup
+"""
+
+import os
+from moduleframework.common import CommonFunctions
+from moduleframework import common
+
+selinux_state_file="/var/tmp/mtf_selinux_state"
+setseto = "Permissive"
+
+
+class EnvOpenShift(CommonFunctions):
+
+    def prepare_env(self):
+        common.print_info('Loaded config for name: {}'.format(self.config['name']))
+        self.__prepare_selinux()
+        self.__start_openshift_cluster()
+
+    def cleanup_env(self):
+        self.__stop_openshift_cluster()
+
+    def __prepare_selinux(self):
+        # disable selinux by default if not turned off
+        if not os.environ.get('MTF_SKIP_DISABLING_SELINUX'):
+            # https://github.com/fedora-modularity/meta-test-family/issues/53
+            # workaround because systemd nspawn is now working well in F-26
+            if not os.path.exists(selinux_state_file):
+                common.print_info("Disabling selinux")
+                actual_state = self.runHost("getenforce", ignore_status=True).stdout.strip()
+                with open(selinux_state_file, 'w') as openfile:
+                    openfile.write(actual_state)
+                if setseto not in actual_state:
+                    self.runHost("setenforce %s" % setseto,
+                                 verbose=common.is_not_silent(),
+                                 sudo=True)
+
+    def __cleanup(self):
+        if not os.environ.get('MTF_SKIP_DISABLING_SELINUX'):
+            common.print_info("Turning back selinux to previous state")
+            actual_state = self.runHost("getenforce", ignore_status=True).stdout.strip()
+            if os.path.exists(selinux_state_file):
+                common.print_info("Turning back selinux to previous state")
+                with open(selinux_state_file, 'r') as openfile:
+                    stored_state = openfile.readline()
+                    if stored_state != actual_state:
+                        self.runHost("setenforce %s" % stored_state,
+                                     ignore_status=True,
+                                     verbose=common.is_not_silent(),
+                                     sudo=True)
+                os.remove(selinux_state_file)
+            else:
+                common.print_info("Selinux state is not stored, skipping.")
+
+    def __oc_status(self):
+        oc_status = self.runHost("oc status", ignore_status=True, verbose=common.is_not_silent())
+        common.print_debug(oc_status.stdout)
+        common.print_debug(oc_status.stderr)
+        return oc_status.exit_status
+
+    def __install_env(self):
+        """
+        Internal method, do not use it anyhow
+
+        :return: None
+        """
+        if os.environ.get('OPENSHIFT_LOCAL'):
+            if not os.path.exists('/usr/bin/oc'):
+                self.installTestDependencies(['origin', 'origin-clients'])
+
+    def __start_openshift_cluster(self):
+        """
+        Internal method, do not use it anyhow. It starts OpenShift cluster
+
+        :return: None
+        """
+
+        if os.environ.get('OPENSHIFT_LOCAL'):
+            if int(self.__oc_status()) == 0:
+                common.print_info("Seems like OpenShift is already started.")
+            else:
+                common.print_info("Starting OpenShift")
+                self.runHost("oc cluster up", verbose=common.is_not_silent())
+
+    def __stop_openshift_cluster(self):
+        """
+        Internal method, do not use it anyhow. It stops OpenShift cluster
+
+        :return: None
+        """
+        if os.environ.get('OPENSHIFT_LOCAL'):
+            if int(self.__oc_status()) == 0:
+                common.print_info("Stopping OpenShift")
+                self.runHost("oc cluster down", verbose=common.is_not_silent())
+            else:
+                common.print_info("OpenShift is already stopped.")
+

--- a/moduleframework/helpers/container_helper.py
+++ b/moduleframework/helpers/container_helper.py
@@ -22,6 +22,7 @@
 
 import json
 from moduleframework.common import *
+from moduleframework.mtfexceptions import ContainerExc
 
 
 class ContainerHelper(CommonFunctions):
@@ -124,7 +125,6 @@ class ContainerHelper(CommonFunctions):
             self.runHost(
                 "docker inspect %s" %
                 self.jmeno, verbose=is_not_silent()).stdout)[0]["Config"]
-
 
     def start(self, args="-it -d", command="/bin/bash"):
         """

--- a/moduleframework/helpers/container_helper.py
+++ b/moduleframework/helpers/container_helper.py
@@ -94,7 +94,7 @@ class ContainerHelper(CommonFunctions):
 
         :return: None
         """
-        super(ContainerHelper,self).tearDown()
+        super(ContainerHelper, self).tearDown()
         if get_if_do_cleanup():
             print_info("To run a command inside a container execute: ",
                         "docker exec %s /bin/bash" % self.docker_id)

--- a/moduleframework/helpers/openshift_helper.py
+++ b/moduleframework/helpers/openshift_helper.py
@@ -1,0 +1,239 @@
+# -*- coding: utf-8 -*-
+#
+# This Modularity Testing Framework helps you to write tests for modules
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# he Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Authors: Petr Hracek <phracek@redhat.com>
+#
+
+import json
+import os
+from moduleframework import common
+from moduleframework.common import CommonFunctions
+from moduleframework.mtfexceptions import ContainerExc, ConfigExc
+
+
+class OpenShiftHelper(CommonFunctions):
+    """
+    Basic Helper class for Docker container module type
+
+    :avocado: disable
+    """
+
+    def __init__(self):
+        """
+        set basic object variables
+        """
+        super(OpenShiftHelper, self).__init__()
+        self.name = None
+        self.docker_id = None
+        self.icontainer = self.get_url()
+        self.containerInfo = None
+        if not self.icontainer:
+            raise ConfigExc("No container image specified in the configuration file or environment variable.")
+        if "docker=" in self.icontainer:
+            self.container_name = self.icontainer[7:]
+        else:
+            # untrusted source
+            self.container_name = self.icontainer
+        # application name is taken from docker.io/modularitycontainer/memcached
+        self.app_name = self.container_name.split('/')[-1]
+        self.app_ip = None
+
+        common.print_info(self.icontainer)
+        common.print_info(self.container_name)
+        common.print_info(self.app_name)
+
+    def get_container_url(self):
+        """
+        It returns actual URL link string to container, It is same as URL
+
+        :return: str
+        """
+        return self.icontainer
+
+    def get_docker_instance_name(self):
+        """
+        Return docker instance name what will be used inside docker as docker image name
+        :return: str
+        """
+        return self.container_name
+
+    def _app_exists(self):
+        common.print_info("OpenShift app_exists")
+        oc_status = self.runHost("oc status", ignore_status=True)
+        if 'dc/%s' % self.app_name in oc_status.stdout:
+            common.print_info("Application already exists.")
+            return True
+        oc_services = self.runHost("oc get services -o json")
+        json_svc = self._convert_string_to_json(oc_services.stdout)
+        common.print_info(json_svc["items"])
+        if not json_svc["items"]:
+            common.print_info("itesms are empty")
+            return False
+        return True
+
+    def _convert_string_to_json(self, string):
+        json_output = json.loads(string)
+        common.print_info(json_output)
+        return json_output
+
+    def _remove_apps_from_openshift_namespaces(self, oc_service="svc"):
+        # Check status of svc/dc/is
+        oc_status = self.runHost("oc status %s" % oc_service, ignore_status=True)
+        common.print_info(oc_status.stdout)
+        # If application exists in svc / dc / is namespace, then remove it
+        oc_delete = self.runHost("oc delete %s/%s" % (oc_service, self.app_name), ignore_status=True)
+        common.print_info(oc_delete.stdout)
+
+    def _app_remove(self):
+        if self._app_exists():
+            common.print_info("Application exists")
+            # TODO get info from oc status and delete relevat svc/dc/is
+            for ns in ['svc', 'dc', 'is']:
+                self._remove_apps_from_openshift_namespaces(ns)
+
+    def _create_app(self):
+        common.print_info("Create_app in OpenShift")
+        # Switching to system user
+        #self._openshift_login(oc_user='system', oc_passwd='admin')
+        common.print_debug(self.container_name, self.app_name)
+        oc_new_app = self.runHost("oc new-app --docker-image=%s --name=%s" % (self.container_name,
+                                                                              self.app_name),
+                                  ignore_status=True)
+        # Switching back to developer user
+        #self._openshift_login()
+        common.print_info(oc_new_app)
+
+    def setUp(self):
+        """
+        It is called by child class and it is same methof as Avocado/Unittest has. It prepares environment
+        for docker testing
+        * start docker if not
+        * pull docker image
+        * setup environment from config
+        * run and store identification
+
+        :return: None
+        """
+        self.icontainer = self.get_url()
+        self.containerInfo = self.__load_inspect_json()
+
+    def _openshift_login(self, oc_ip="127.0.0.1", oc_user='developer', oc_passwd='developer', env=False):
+        if env:
+            if 'OPENSHIFT_IP' in os.environ:
+                oc_ip = os.environ.get('OPENSHIFT_IP')
+            if 'OPENSHIFT_USER' in os.environ:
+                oc_user = os.environ.get('OPENSHIFT_USER')
+            if 'OPENSHIFT_PWD' in os.environ:
+                oc_passwd = os.environ.get('OPENSHIFT_PWD')
+
+        oc_output = self.runHost("oc login %s:8443 --username=%s --password=%s" % (oc_ip,
+                                                                                   oc_user,
+                                                                                   oc_passwd),
+                                 verbose=common.is_not_silent())
+        common.print_debug(oc_output.stderr)
+        common.print_debug(oc_output.stdout)
+        return oc_output.exit_status
+
+    def tearDown(self):
+        """
+        Cleanup environment and call also cleanup from config
+
+        :return: None
+        """
+        super(OpenShiftHelper, self).tearDown()
+        if common.get_if_do_cleanup():
+            common.print_info("To run a command inside a container execute: ",
+                        "docker exec %s /bin/bash" % self.docker_id)
+
+    def __load_inspect_json(self):
+        """
+        Load json data from docker inspect command
+
+        :return: dict
+        """
+        return json.loads(
+            self.runHost(
+                "docker inspect %s" %
+                self.container_name, verbose=common.is_not_silent()).stdout)[0]["Config"]
+
+    def _get_ip_instance(self):
+        """
+        Function return IP address of OpenShift POD.
+        :return:
+        """
+        oc_get_service = self.runHost("oc get service -o json")
+        service = self._convert_string_to_json(oc_get_service.stdout)
+        try:
+            common.print_info(service["items"])
+            common.print_info(service["items"][0])
+            common.print_info(service["items"][0]["spec"])
+            self.app_ip = service["items"][0]["spec"]["clusterIP"]
+            common.trans_dict['GUESTIPADDR'] = self.app_ip
+            common.print_info(common.trans_dict)
+            return True
+        except KeyError as e:
+            common.print_info(e.message)
+            return False
+
+    def start(self):
+        """
+        start the OpenShift application
+
+        :param args: Do not use it directly (It is defined in config.yaml)
+        :param command: Do not use it directly (It is defined in config.yaml)
+        :return: None
+        """
+        common.print_info("OpenShift start")
+        if not self._app_exists():
+            self._create_app()
+            self._get_ip_instance()
+
+    def stop(self):
+        """
+        Stop the docker container
+
+        :return: None
+        """
+        if self.status():
+            try:
+                self._app_remove()
+            except Exception as e:
+                common.print_debug(e, "OpenShift application already removed")
+                pass
+
+    def status(self):
+        """
+        get status if OpenShift is running
+
+        :return: bool
+        """
+        if self._app_exists():
+            return True
+        else:
+            return False
+
+    def run(self, command="ls /", **kwargs):
+        """
+        Run command inside module, all params what allows avocado are passed inside shell,ignore_status, etc.
+
+        :param command: str
+        :param kwargs: dict
+        :return: avocado.process.run
+        """
+        return self.runHost("%s" % common.sanitize_cmd(command), **kwargs)

--- a/moduleframework/helpers/openshift_helper.py
+++ b/moduleframework/helpers/openshift_helper.py
@@ -288,10 +288,13 @@ class OpenShiftHelper(ContainerHelper):
 
     def run(self, command="ls /", **kwargs):
         """
-        Run command inside module, all params what allows avocado are passed inside shell,ignore_status, etc.
+        Run command inside OpenShift POD, all params what allows avocado are passed inside shell,ignore_status, etc.
+        https://docs.openshift.com/container-platform/3.6/dev_guide/executing_remote_commands.html
 
         :param command: str
         :param kwargs: dict
         :return: avocado.process.run
         """
-        return self.runHost("%s" % common.sanitize_cmd(command), **kwargs)
+        return self.runHost("oc exec %s %s" % (self.pod_id,
+                                               common.sanitize_cmd(command)),
+                            **kwargs)

--- a/moduleframework/helpers/rpm_helper.py
+++ b/moduleframework/helpers/rpm_helper.py
@@ -23,6 +23,7 @@
 from moduleframework import pdc_data
 from moduleframework.common import *
 
+
 class RpmHelper(CommonFunctions):
     """
     Class for testing "modules" on local machine (host) directly. It could be used for scheduling tests for

--- a/moduleframework/module_framework.py
+++ b/moduleframework/module_framework.py
@@ -30,6 +30,7 @@ from moduleframework.avocado_testers.avocado_test import AvocadoTest, get_backen
 from moduleframework.avocado_testers.container_avocado_test import ContainerAvocadoTest
 from moduleframework.avocado_testers.nspawn_avocado_test import NspawnAvocadoTest
 from moduleframework.avocado_testers.rpm_avocado_test import RpmAvocadoTest
+from moduleframework.avocado_testers.openshift_avocado_test import OpenShiftAvocadoTest
 from moduleframework.mtfexceptions import ModuleFrameworkException
 
 PROFILE = None

--- a/moduleframework/mtf_environment.py
+++ b/moduleframework/mtf_environment.py
@@ -28,6 +28,7 @@ from moduleframework.common import get_module_type_base, print_info
 from moduleframework.environment_prepare.docker_prepare import EnvDocker
 from moduleframework.environment_prepare.rpm_prepare import EnvRpm
 from moduleframework.environment_prepare.nspawn_prepare import EnvNspawn
+from moduleframework.environment_prepare.openshift_prepare import EnvOpenShift
 
 
 module_name = get_module_type_base()
@@ -39,6 +40,8 @@ elif module_name == "rpm":
     env = EnvRpm()
 elif module_name == "nspawn":
     env = EnvNspawn()
+elif module_name == "openshift":
+    env = EnvOpenShift()
 
 
 def mtfenvset():

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,6 @@ paths = ['man']
 
 for path in paths:
     for root, dirs, files in os.walk(path, followlinks=True):
-        print(root, dirs, files)
         data_files[
             get_dir(
                 ['usr', 'share', 'man', 'man1'])] = [


### PR DESCRIPTION
This Pull Request brings possibility to test containers in OpenShift environment.

MTF provides two scripts for preparing environment like `MODULE=openshift mtf-env-set` and `MODULE=openshift mtf-env-clean`

Usage is like:
`MODULE=openshift OPENSHIFT_IP="Openshift_IP_Address" OPENSHIFT_USERNAME=developer OPENSHIFT_PASSWD=developer mtf -l *.py`

The Pull Request fixes issue #89 