### PR TITLE
remove avocado html plugin from python dependencies, it is not import…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 PyYAML
 avocado-framework
-avocado-framework-plugin-result-html
 dockerfile-parse
 modulemd
 netifaces


### PR DESCRIPTION
…ant for mtf anyhow