### PR TITLE
Fixes #209 Messages for linter errors

### DIFF
--- a/moduleframework/dockerlinter.py
+++ b/moduleframework/dockerlinter.py
@@ -117,7 +117,10 @@ class DockerfileLinter(object):
         if env_name is None:
             return []
         env_list = self.get_docker_env()
-        return [x for x in env_list if env_name in x]
+        try:
+            return [x for x in env_list if env_name in x]
+        except TypeError:
+            return None
 
     def get_docker_expose(self):
         """

--- a/moduleframework/tests/generic/dockerlint.py
+++ b/moduleframework/tests/generic/dockerlint.py
@@ -48,9 +48,10 @@ class DockerfileLinterInContainer(container_avocado_test.ContainerAvocadoTest):
         self.start()
         all_docs = self.run("rpm -qad", verbose=False).stdout
         test_failed = self._file_to_check(all_docs.split('\n'))
+        msg = "Documentation files exist in container. They are installed by Platform or by RUN commands."
         if test_failed:
-            self.log.warn("Documentation files exist in container. They are installed by Platform or by RUN commands.")
-        self.assertTrue(True)
+            self.log.warn(msg)
+        self.assertTrue(True, msg=msg)
 
     def test_installed_docs(self):
         """
@@ -70,7 +71,7 @@ class DockerfileLinterInContainer(container_avocado_test.ContainerAvocadoTest):
             pkg_doc = self.run("rpm -qd %s" % pkg, verbose=False).stdout
             if self._file_to_check(pkg_doc.split('\n')):
                 test_failed = True
-        self.assertFalse(test_failed)
+        self.assertFalse(test_failed, msg="In container are installed some docs.")
 
     def _check_container_files(self, exts, pkg_mgr):
         found_files = False
@@ -120,9 +121,9 @@ class DockerfileLinterInContainer(container_avocado_test.ContainerAvocadoTest):
         # Detect distro in image
         distro = self.run("cat /etc/os-release").stdout
         if 'Fedora' in distro:
-            self.assertFalse(self._dnf_clean_all())
+            self.assertFalse(self._dnf_clean_all(), msg="`dnf clean all` is not present in Dockerfile.")
         else:
-            self.assertFalse(self._yum_clean_all())
+            self.assertFalse(self._yum_clean_all(), msg="`yum clean all` is not present in Dockerfile.")
 
 
 class DockerLint(container_avocado_test.ContainerAvocadoTest):
@@ -141,5 +142,6 @@ class DockerLint(container_avocado_test.ContainerAvocadoTest):
             self.log.info("No labels defined in config to check")
             self.cancel()
         for key in self.getConfigModule()['labels']:
+            print(self.getConfigModule()['labels'][key])
             aaa = self.checkLabel(key, self.getConfigModule()['labels'][key])
-            self.assertTrue(aaa)
+            self.assertTrue(aaa, msg="Label %s is not set properly in modulemd YAML file." % key)

--- a/moduleframework/tests/static/dockerfile_lint.py
+++ b/moduleframework/tests/static/dockerfile_lint.py
@@ -22,19 +22,19 @@ class DockerInstructionsTests(module_framework.AvocadoTest):
             self.skip("Dockerfile was not found")
 
     def test_from_is_first_directive(self):
-        self.assertTrue(self.dp.check_from_is_first())
+        self.assertTrue(self.dp.check_from_is_first(), msg="FROM instruction is not first.")
 
     def test_from_directive_is_valid(self):
-        self.assertTrue(self.dp.check_from_directive_is_valid())
+        self.assertTrue(self.dp.check_from_directive_is_valid(), msg="FROM instruction is not valid.")
 
     def test_chained_run_dnf_commands(self):
-        self.assertTrue(self.dp.check_chained_run_dnf_commands())
+        self.assertTrue(self.dp.check_chained_run_dnf_commands(), msg="dnf/yum commands are not chained.")
 
     def test_chained_run_rest_commands(self):
-        self.assertTrue(self.dp.check_chained_run_rest_commands())
+        self.assertTrue(self.dp.check_chained_run_rest_commands(), msg="rest dnf/yum commands in image are not chained.")
 
     def test_helpmd_is_present(self):
-        self.assert_to_warn(self.assertTrue, self.dp.check_helpmd_is_present())
+        self.assert_to_warn(self.assertTrue, self.dp.check_helpmd_is_present(), msg="helpmd is not present for this container.")
 
 
 class DockerLabelsTests(DockerInstructionsTests):
@@ -54,29 +54,34 @@ class DockerLabelsTests(DockerInstructionsTests):
             label_found = self.dp.get_specific_label(docker_label)
         return label_found
 
+    def _get_msg(self, label):
+        return label + " is missing in Dockerfile."
+
     def test_architecture_in_env_and_label_exists(self):
-        self.assertTrue(self.dp.get_specific_label("architecture"))
+        self.assertTrue(self.dp.get_specific_label("architecture"),msg=self._get_msg("architecture env and label"))
 
     def test_name_in_env_and_label_exists(self):
-        self.assertTrue(self.dp.get_docker_specific_env("NAME="))
-        self.assertTrue(self.dp.get_specific_label("name"))
+        self.assertTrue(self.dp.get_docker_specific_env("NAME="), msg=self._get_msg("Environment variable NAME"))
+        self.assertTrue(self.dp.get_specific_label("name"), msg=self._get_msg("Label name"))
 
     def test_maintainer_label_exists(self):
-        self.assertTrue(self.dp.get_specific_label("maintainer"))
+        self.assertTrue(self.dp.get_specific_label("maintainer"), msg=self._get_msg("Label maintainer"))
 
     def test_release_label_exists(self):
-        self.assertTrue(self.dp.get_specific_label("release"))
+        self.assertTrue(self.dp.get_specific_label("release"), msg=self._get_msg("Label release"))
 
     def test_version_label_exists(self):
-        self.assertTrue(self.dp.get_specific_label("version"))
+        self.assertTrue(self.dp.get_specific_label("version"), msg=self._get_msg("Label version"))
 
     def test_com_redhat_component_label_exists(self):
-        self.assertTrue(self.dp.get_specific_label("com.redhat.component"))
+        self.assertTrue(self.dp.get_specific_label("com.redhat.component"),
+                        msg=self._get_msg("Label com.redhat.component"))
 
     def test_summary_label_exists(self):
-        self.assertTrue(self.dp.get_specific_label("summary"))
+        self.assertTrue(self.dp.get_specific_label("summary"), msg=self._get_msg("Label summary"))
 
     def test_run_or_usage_label_exists(self):
-        self.assertTrue(self._test_for_env_and_label("run", "usage", env=False))
+        self.assertTrue(self._test_for_env_and_label("run", "usage", env=False),
+                        msg=self._get_msg("Label run or usage"))
 
 

--- a/moduleframework/tests/static/helpmd_lint.py
+++ b/moduleframework/tests/static/helpmd_lint.py
@@ -47,31 +47,40 @@ class HelpFileSanity(module_framework.AvocadoTest):
     def tearDown(self, *args, **kwargs):
         pass
 
+    def get_msg(self, msg):
+        return msg + " is missing in help.md file."
     def test_helpmd_exists(self):
-        self.assertTrue(self.helpmd)
+        self.assertTrue(self.helpmd, msg="Help.md file is not present")
 
     def test_helpmd_image_name(self):
         container_name = self.dp.get_docker_specific_env("NAME=")
         if container_name:
-            self.assertTrue(self.helpmd.get_image_name(container_name[0].split('=')[1]))
+            self.assertTrue(self.helpmd.get_image_name(container_name[0].split('=')[1]),
+                            msg=self.get_msg("image name"))
 
     def test_helpmd_maintainer_name(self):
         maintainer_name = self.dp.get_specific_label("maintainer")
         if maintainer_name:
-            self.assertTrue(self.helpmd.get_maintainer_name(maintainer_name[0]))
+            self.assertTrue(self.helpmd.get_maintainer_name(maintainer_name[0]),
+                            msg=self.get_msg("maintainer"))
 
     def test_helpmd_name(self):
-        self.assertTrue(self.helpmd.get_tag("NAME"))
+        self.assertTrue(self.helpmd.get_tag("NAME"),
+                        msg=self.get_msg("NAME section"))
 
     def test_helpmd_description(self):
-        self.assertTrue(self.helpmd.get_tag("DESCRIPTION"))
+        self.assertTrue(self.helpmd.get_tag("DESCRIPTION"),
+                        msg=self.get_msg("DESCRIPTION section"))
 
     def test_helpmd_usage(self):
-        self.assertTrue(self.helpmd.get_tag("USAGE"))
+        self.assertTrue(self.helpmd.get_tag("USAGE"),
+                        msg=self.get_msg("USAGE section"))
 
     def test_helpmd_environment_variables(self):
-        self.assert_to_warn(self.assertTrue, self.helpmd.get_tag("ENVIRONMENT VARIABLES"))
+        self.assert_to_warn(self.assertTrue, self.helpmd.get_tag("ENVIRONMENT VARIABLES"),
+                            msg=self.get_msg("ENVIRONMENT VARIABLES section"))
 
     def test_helpmd_security_implications(self):
         if self.dp.get_docker_expose():
-            self.assertTrue(self.helpmd.get_tag("SECURITY IMPLICATIONS"))
+            self.assertTrue(self.helpmd.get_tag("SECURITY IMPLICATIONS"),
+                            msg=self.get_msg("SECURITY IMPLICATIONS section"))


### PR DESCRIPTION
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>

This Pull Request fixes issue #209 .

The output now looks like:
```
RESULTS    : PASS 10 | ERROR 0 | FAIL 14 | SKIP 0 | WARN 3 | INTERRUPT 0 | CANCEL 1
JOB TIME   : 193.43 s
JOB HTML   : /root/avocado/job-results/job-2018-02-13T16.31-fb2334a/results.html

TEST:   06-/usr/lib/python2.7/site-packages/moduleframework/tests/generic/dockerlint.py:DockerLint.testLabels
ERROR:  Label io.k8s.description is not set properly in modulemd YAML file.
        /root/avocado/job-results/job-2018-02-13T16.31-fb2334a/test-results/06-_usr_lib_python2.7_site-packages_moduleframework_tests_generic_dockerlint.py_DockerLint.testLabels/debug.log
-------------------------
TEST:   11-/usr/lib/python2.7/site-packages/moduleframework/tests/static/helpmd_lint.py:HelpFileSanity.test_helpmd_name
ERROR:  NAME section is missing in help.md file.
        /root/avocado/job-results/job-2018-02-13T16.31-fb2334a/test-results/11-_usr_lib_python2.7_site-packages_moduleframework_tests_static_helpmd_lint.py_HelpFileSanity.test_helpmd_name/debug.log
-------------------------
TEST:   12-/usr/lib/python2.7/site-packages/moduleframework/tests/static/helpmd_lint.py:HelpFileSanity.test_helpmd_description
ERROR:  DESCRIPTION section is missing in help.md file.
        /root/avocado/job-results/job-2018-02-13T16.31-fb2334a/test-results/12-_usr_lib_python2.7_site-packages_moduleframework_tests_static_helpmd_lint.py_HelpFileSanity.test_helpmd_description/debug.log
-------------------------
TEST:   13-/usr/lib/python2.7/site-packages/moduleframework/tests/static/helpmd_lint.py:HelpFileSanity.test_helpmd_usage
ERROR:  USAGE section is missing in help.md file.
        /root/avocado/job-results/job-2018-02-13T16.31-fb2334a/test-results/13-_usr_lib_python2.7_site-packages_moduleframework_tests_static_helpmd_lint.py_HelpFileSanity.test_helpmd_usage/debug.log
-------------------------
TEST:   15-/usr/lib/python2.7/site-packages/moduleframework/tests/static/helpmd_lint.py:HelpFileSanity.test_helpmd_security_implications
ERROR:  SECURITY IMPLICATIONS section is missing in help.md file.
        /root/avocado/job-results/job-2018-02-13T16.31-fb2334a/test-results/15-_usr_lib_python2.7_site-packages_moduleframework_tests_static_helpmd_lint.py_HelpFileSanity.test_helpmd_security_implications/debug.log
-------------------------
TEST:   18-/usr/lib/python2.7/site-packages/moduleframework/tests/static/dockerfile_lint.py:DockerInstructionsTests.test_chained_run_dnf_commands
ERROR:  dnf/yum commands are not chained.
        /root/avocado/job-results/job-2018-02-13T16.31-fb2334a/test-results/18-_usr_lib_python2.7_site-packages_moduleframework_tests_static_dockerfile_lint.py_DockerInstructionsTests.test_chained_run_dnf_commands/debug.log
-------------------------
TEST:   21-/usr/lib/python2.7/site-packages/moduleframework/tests/static/dockerfile_lint.py:DockerLabelsTests.test_architecture_in_env_and_label_exists
ERROR:  architecture env and label is missing in Dockerfile.
        /root/avocado/job-results/job-2018-02-13T16.31-fb2334a/test-results/21-_usr_lib_python2.7_site-packages_moduleframework_tests_static_dockerfile_lint.py_DockerLabelsTests.test_architecture_in_env_and_label_exists/debug.log
-------------------------
TEST:   22-/usr/lib/python2.7/site-packages/moduleframework/tests/static/dockerfile_lint.py:DockerLabelsTests.test_name_in_env_and_label_exists
ERROR:  Environment variable NAME is missing in Dockerfile.
        /root/avocado/job-results/job-2018-02-13T16.31-fb2334a/test-results/22-_usr_lib_python2.7_site-packages_moduleframework_tests_static_dockerfile_lint.py_DockerLabelsTests.test_name_in_env_and_label_exists/debug.log
-------------------------
TEST:   23-/usr/lib/python2.7/site-packages/moduleframework/tests/static/dockerfile_lint.py:DockerLabelsTests.test_maintainer_label_exists
ERROR:  Label maintainer is missing in Dockerfile.
        /root/avocado/job-results/job-2018-02-13T16.31-fb2334a/test-results/23-_usr_lib_python2.7_site-packages_moduleframework_tests_static_dockerfile_lint.py_DockerLabelsTests.test_maintainer_label_exists/debug.log
-------------------------
TEST:   24-/usr/lib/python2.7/site-packages/moduleframework/tests/static/dockerfile_lint.py:DockerLabelsTests.test_release_label_exists
ERROR:  Label release is missing in Dockerfile.
        /root/avocado/job-results/job-2018-02-13T16.31-fb2334a/test-results/24-_usr_lib_python2.7_site-packages_moduleframework_tests_static_dockerfile_lint.py_DockerLabelsTests.test_release_label_exists/debug.log
-------------------------
TEST:   25-/usr/lib/python2.7/site-packages/moduleframework/tests/static/dockerfile_lint.py:DockerLabelsTests.test_version_label_exists
ERROR:  Label version is missing in Dockerfile.
        /root/avocado/job-results/job-2018-02-13T16.31-fb2334a/test-results/25-_usr_lib_python2.7_site-packages_moduleframework_tests_static_dockerfile_lint.py_DockerLabelsTests.test_version_label_exists/debug.log
-------------------------
TEST:   26-/usr/lib/python2.7/site-packages/moduleframework/tests/static/dockerfile_lint.py:DockerLabelsTests.test_com_redhat_component_label_exists
ERROR:  Label com.redhat.component is missing in Dockerfile.
        /root/avocado/job-results/job-2018-02-13T16.31-fb2334a/test-results/26-_usr_lib_python2.7_site-packages_moduleframework_tests_static_dockerfile_lint.py_DockerLabelsTests.test_com_redhat_component_label_exists/debug.log
-------------------------
TEST:   27-/usr/lib/python2.7/site-packages/moduleframework/tests/static/dockerfile_lint.py:DockerLabelsTests.test_summary_label_exists
ERROR:  Label summary is missing in Dockerfile.
        /root/avocado/job-results/job-2018-02-13T16.31-fb2334a/test-results/27-_usr_lib_python2.7_site-packages_moduleframework_tests_static_dockerfile_lint.py_DockerLabelsTests.test_summary_label_exists/debug.log
-------------------------
TEST:   28-/usr/lib/python2.7/site-packages/moduleframework/tests/static/dockerfile_lint.py:DockerLabelsTests.test_run_or_usage_label_exists
ERROR:  Label run or usage is missing in Dockerfile.
        /root/avocado/job-results/job-2018-02-13T16.31-fb2334a/test-results/28-_usr_lib_python2.7_site-packages_moduleframework_tests_static_dockerfile_lint.py_DockerLabelsTests.test_run_or_usage_label_exists/debug.log
make[1]: *** [Makefile:4: test_mtf] Error 1
make[1]: Leaving directory '/home/phracek/work/container-images/memcached/tests'
make: *** [Makefile:28: test] Error 2
✘-2 ~/work/container-images/memcached [master|✚ 3…4⚑ 2] 

```