### PR TITLE
print testcase function, print doc string (class and test method)

### DIFF
--- a/moduleframework/mtf_scheduler.py
+++ b/moduleframework/mtf_scheduler.py
@@ -256,13 +256,14 @@ class AvocadoStart(object):
         Main purpose is to display docstrings of testcases for failures
         example:
             def test_some(something)
-                \"\"\"
+                '''
                 This is line1.
                 This is line2.
                 :return: None
-                \"\"\"\
-                assert(Fasle)
+                '''
+                self.assertTrue(False, msg="This is fail reason")
         procudes line:    desc -> This is line1. This is line2.
+                          reason -> This is fail reason
         :param testcases: dict of testcases
         :param header: str what to print as header
         :param logs: boolean if print logs for these testcases (default True)


### PR DESCRIPTION
avoid code duplication
and output looks like:
```
15:57 $ mtf --module docker --url fedora /home/jscotka/git/meta-test-family/moduleframework/tests/generic/dockerlint.py
JOB ID     : 948dd107a1bb1a1242d12caf14d11cbc00cf3001
JOB LOG    : /home/jscotka/avocado/job-results/job-2018-02-28T15.57-948dd10/job.log
 (1/4) /home/jscotka/git/meta-test-family/moduleframework/tests/generic/dockerlint.py:DockerfileLinterInContainer.test_all_nodocs: ERROR (0.04 s)
 (2/4) /home/jscotka/git/meta-test-family/moduleframework/tests/generic/dockerlint.py:DockerfileLinterInContainer.test_installed_docs: ERROR (0.02 s)
 (3/4) /home/jscotka/git/meta-test-family/moduleframework/tests/generic/dockerlint.py:DockerfileLinterInContainer.test_docker_clean_all: ERROR (0.02 s)
 (4/4) /home/jscotka/git/meta-test-family/moduleframework/tests/generic/dockerlint.py:DockerLint.testLabels: ERROR (0.02 s)
RESULTS    : PASS 0 | ERROR 4 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 0
JOB TIME   : 1.01 s

------------------------ FAILED TESTS ------------------------
TEST ERROR:  /home/jscotka/git/meta-test-family/moduleframework/tests/generic/dockerlint.py:DockerfileLinterInContainer.test_all_nodocs
     desc -> Test if all RPM does not contain docs packed
     reason -> Command 'docker pull fedora' failed (rc=1)
     /home/jscotka/avocado/job-results/job-2018-02-28T15.57-948dd10/test-results/1-_home_jscotka_git_meta-test-family_moduleframework_tests_generic_dockerlint.py_DockerfileLinterInContainer.test_all_nodocs/debug.log

TEST ERROR:  /home/jscotka/git/meta-test-family/moduleframework/tests/generic/dockerlint.py:DockerfileLinterInContainer.test_installed_docs
     desc -> This test checks whether no docs are installed by RUN dnf command                  PASS in case there is no doc file found
     reason -> Command 'docker pull fedora' failed (rc=1)
     /home/jscotka/avocado/job-results/job-2018-02-28T15.57-948dd10/test-results/2-_home_jscotka_git_meta-test-family_moduleframework_tests_generic_dockerlint.py_DockerfileLinterInContainer.test_installed_docs/debug.log

TEST ERROR:  /home/jscotka/git/meta-test-family/moduleframework/tests/generic/dockerlint.py:DockerfileLinterInContainer.test_docker_clean_all
     desc -> This test checks if `dnf/yum clean all` was called in image                   return False if clean all is not called
     reason -> Command 'docker pull fedora' failed (rc=1)
     /home/jscotka/avocado/job-results/job-2018-02-28T15.57-948dd10/test-results/3-_home_jscotka_git_meta-test-family_moduleframework_tests_generic_dockerlint.py_DockerfileLinterInContainer.test_docker_clean_all/debug.log

TEST ERROR:  /home/jscotka/git/meta-test-family/moduleframework/tests/generic/dockerlint.py:DockerLint.testLabels
     desc -> Function tests whether labels are set in modulemd YAML file properly.
     reason -> Command 'docker pull fedora' failed (rc=1)
     /home/jscotka/avocado/job-results/job-2018-02-28T15.57-948dd10/test-results/4-_home_jscotka_git_meta-test-family_moduleframework_tests_generic_dockerlint.py_DockerLint.testLabels/debug.log
```