### PR TITLE
before run avocado, list tests and find if there are some bad tests

### DIFF
--- a/examples/testing-module/Makefile
+++ b/examples/testing-module/Makefile
@@ -42,6 +42,10 @@ check-run-them-fedmsg-testmodule: prepare-nspawn
 	../../tools/run-them.sh testmodule ../../tools/example_message_module.yaml fedmsg
 
 check-exceptions: prepare-docker
+	$(CMD) bad_test_name second_invalid && false || true
+	$(CMD) bad_test_name second_invalid 2>&1 | grep 'bad_test_name: File not found'
+	$(CMD) bad_test_name second_invalid 2>&1 | grep 'second_invalid: File not found'
+
 	URL=NOT_VALID_URL MODULE=docker $(CMD) --show-job-log simpleTest.py 2>&1 | grep 'raise.*CmdError'
 	CONFIG=NOT_VALID_CONFIG MODULE=docker $(CMD) --show-job-log simpleTest.py 2>&1 | grep 'raise.*ConfigExc'
 

--- a/moduleframework/common.py
+++ b/moduleframework/common.py
@@ -747,7 +747,7 @@ def get_config(fail_without_url=True, reload=False):
                 core.print_debug("Using module config file: %s" % cfgfile)
             else:
                 if fail_without_url and not get_url():
-                    raise mtfexceptions.Defaultmtfexceptions.ConfigExc("You have to use URL envvar for testing your images or repos")
+                    raise mtfexceptions.DefaultConfigExc("You have to use URL envvar for testing your images or repos")
                 cfgfile = "/usr/share/moduleframework/docs/example-config-minimal.yaml"
                 core.print_debug("Using default minimal config: %s" % cfgfile)
 

--- a/moduleframework/mtf_scheduler.py
+++ b/moduleframework/mtf_scheduler.py
@@ -258,18 +258,16 @@ class AvocadoStart(object):
         # remove header line and remove last lines with is test types summary
         testlines = []
         for line in output.split("\n"):
-            if line.startswith(prefix_line) or not line.strip():
+            testline = line.strip()
+            if testline.startswith(prefix_line) or not testline:
                 continue
-            elif line.startswith(summary_line):
+            elif testline.startswith(summary_line):
                 break
             else:
-                testlines.append(line.strip())
-        for testline in testlines:
-            splitted = testline.split(" ", 1)
-            if splitted[0] in badstates:
-                badtests.append(splitted[1].strip())
+                splitted = testline.split(" ", 1)
+                if splitted[0] in badstates:
+                    badtests.append(splitted[1].strip())
         if badtests:
-
             core.print_info("", "ERROR: There are bad tests:", "-------------")
             core.print_info(*badtests)
             exit(19)

--- a/moduleframework/mtf_scheduler.py
+++ b/moduleframework/mtf_scheduler.py
@@ -197,7 +197,15 @@ class AvocadoStart(object):
     json_tmppath = None
     additionalAvocadoArg = []
     AVOCADO = "avocado"
-
+    A_KNOWN_PARAMS_SIMPLE=["-s", "-z", "-v", "-V",
+                           "--silent",
+                           "--show-job-log",
+                           "--replay-resume",
+                           "--filter-by-tags-include-empty",
+                           "--archive",
+                           "--journal",
+                           "--"
+                           ]
     def __init__(self, args, unknown):
         # choose between TESTS and ADDITIONAL ENVIRONMENT from options
         if args.linter:
@@ -209,16 +217,27 @@ class AvocadoStart(object):
                 STATIC_LINTERS=common.conf["generic"]["static_tests"]))
         self.args = args
 
-        for param in unknown:
-            # take care of this, see tags for safe/unsafe:
-            # http://avocado-framework.readthedocs.io/en/52.0/WritingTests.html#categorizing-tests
-            testlist = glob.glob(param)
-            if testlist:
-                # this is list of tests in local file
+        # parse unknow options and try to find what parameter is test
+        while unknown:
+            if unknown[0] in self.A_KNOWN_PARAMS_SIMPLE:
+                self.additionalAvocadoArg.append(unknown[0])
+                unknown = unknown[1:]
+            elif unknown[0].startswith("-"):
+                if len(unknown) >= 2:
+                    self.additionalAvocadoArg += unknown[0:2]
+                    unknown = unknown[2:]
+                else:
+                    self.additionalAvocadoArg.append(unknown[0])
+                    unknown = unknown[1:]
+            elif glob.glob(unknown[0]):
+                # dereference filename via globs
+                testlist = glob.glob(unknown[0])
                 self.tests += testlist
+                unknown = unknown[1:]
             else:
-                # this is additional avocado param
-                self.additionalAvocadoArg.append(param)
+                self.tests.append(unknown[0])
+                unknown = unknown[1:]
+
         if self.args.metadata:
             core.print_info("Using Metadata loader for tests and filtering")
             metadata_tests = filtertests(backend="mtf", location=os.getcwd(), linters=False, tests=[], tags=[], relevancy="")
@@ -229,21 +248,40 @@ class AvocadoStart(object):
         core.print_debug("additionalAvocadoArg = {0}".format(
             self.additionalAvocadoArg))
 
+    def check_tests(self):
+        output = subprocess.check_output([self.AVOCADO, "list", "-V", "--"] + self.tests)
+        assert "TEST TYPES SUMMARY" in output
+        badstates = ["NOT_A_TEST", "MISSING", "ACCESS_DENIED", "BROKEN_SYMLINK"]
+        badtests = []
+        # remove fist line, it is header, and remove last 11 lines, what is test summary
+        for testline in output.split("\n")[1:-11]:
+            splitted = testline.strip().split(" ", 1)
+            if splitted[0] in badstates:
+                badtests.append(splitted[1].strip())
+        if badtests:
+
+            core.print_info("", "ERROR: There are bad tests:", "-------------")
+            core.print_info(*badtests)
+            exit(19)
 
     def avocado_run(self):
+        self.check_tests()
         self.json_tmppath = tempfile.mktemp()
         avocado_args = ["--json", self.json_tmppath]
         if self.args.xunit:
             avocado_args += ["--xunit", self.args.xunit]
-        return self.avocado_general(avocado_default_args=avocado_args)
+        return self.avocado_general(action=self.args.action, avocado_default_args=avocado_args)
 
-    def avocado_general(self, avocado_default_args=[]):
-        # additional parameters
-        # self.additionalAvocadoArg: its from cmd line, whats unknown to this tool
-        avocadoAction = [self.AVOCADO, self.args.action] + avocado_default_args
+    def avocado_general(self, action, avocado_default_args=[]):
+        """
+
+        :param action: what avocado action to run: run, list, ...
+        :param avocado_default_args: list avocado additional argument
+        :return: return code of executed avocado command
+        """
         rc=0
         try:
-            subprocess.check_call(avocadoAction + self.additionalAvocadoArg + self.tests)
+            subprocess.check_call([self.AVOCADO, action] + avocado_default_args + self.additionalAvocadoArg + self.tests)
         except subprocess.CalledProcessError as cpe:
             rc = cpe.returncode
         return rc
@@ -340,7 +378,7 @@ def main():
         a.show_error()
     else:
         # when there is any need, change general method or create specific one:
-        returncode = a.avocado_general()
+        returncode = a.avocado_general(action=args.action)
     exit(returncode)
 
 


### PR DESCRIPTION
example output:
```
mtf -l --url=fedora a c vs ds sd  /root
MTF config dir exists, search for /usr/share/moduleframework/mtf.conf.d/*.yaml
MTF config load: /usr/share/moduleframework/mtf.conf.d/mtf.yaml

ERROR: There are bad tests:
-------------
a: File not found ('a'; '/usr/share/avocado/tests/a')
c: File not found ('c'; '/usr/share/avocado/tests/c')
vs: File not found ('vs'; '/usr/share/avocado/tests/vs')
ds: File not found ('ds'; '/usr/share/avocado/tests/ds')
sd: Is a broken symlink
/root: Is not readable
```
ls output:
```
ls  a c vs ds sd  /root
ls: cannot access 'a': No such file or directory
ls: cannot access 'c': No such file or directory
ls: cannot access 'vs': No such file or directory
ls: cannot access 'ds': No such file or directory
sd

ls: cannot open directory '/root': Permission denied
```