### PR TITLE
Fixes #221 Showing reg exp for detection and FROM intruction.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ before_script:
 
 script:
   - sudo make travis
+  - sudo make -C examples/mtf-linters check-linters
   - sudo make -C examples/testing-module check-inheritance
   - sudo make -C examples/testing-module check-default-config
   - sudo make -C examples/testing-module check-pure-docker

--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,11 @@ check:
 
 check-linter:
 	@# don't use $(shell ) -- it messes out output
-	cd examples/linter/tools && PYTHONPATH=${PWD} MODULE=docker ${PWD}/tools/mtf -l
-	cd examples/linter/rhscl-postgresql && PYTHONPATH=${PWD} MODULE=docker ${PWD}/tools/mtf -l
-	cd examples/linter/rhscl-nginx && PYTHONPATH=${PWD} MODULE=docker ${PWD}/tools/mtf -l
-	cd examples/linter/f26-etcd && PYTHONPATH=${PWD} MODULE=docker ${PWD}/tools/mtf -l
-	cd examples/linter/f26-flannel && PYTHONPATH=${PWD} MODULE=docker ${PWD}/tools/mtf -l
+	cd examples/linter/tools && PYTHONPATH=${PWD} MODULE=docker ${PWD}/${NAME}/mtf_scheduler.py -l
+	cd examples/linter/rhscl-postgresql && PYTHONPATH=${PWD} MODULE=docker ${PWD}/${NAME}/mtf_scheduler.py -l
+	cd examples/linter/rhscl-nginx && PYTHONPATH=${PWD} MODULE=docker ${PWD}/${NAME}/mtf_scheduler.py -l
+	cd examples/linter/f26-etcd && PYTHONPATH=${PWD} MODULE=docker ${PWD}/${NAME}/mtf_scheduler.py -l
+	cd examples/linter/f26-flannel && PYTHONPATH=${PWD} MODULE=docker ${PWD}/${NAME}/mtf_scheduler.py -l
 
 travis:
 	make -C examples/testing-module travis

--- a/examples/mtf-linters/Makefile
+++ b/examples/mtf-linters/Makefile
@@ -1,0 +1,4 @@
+.PHONY: check-linters
+
+check-linters:
+	pytest test_linters.py

--- a/examples/mtf-linters/test_linters.py
+++ b/examples/mtf-linters/test_linters.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import print_function
+from moduleframework.dockerlinter import DockerfileLinter
+import pytest
+import os
+import tempfile
+def save_docker_file(content):
+    temp = tempfile.NamedTemporaryFile(delete=False)
+    try:
+        temp.write(content)
+        temp.seek(0)
+    finally:
+        temp.close()
+    return temp.name
+
+
+def prepare_linter(content):
+    filename = save_docker_file(content)
+    os.environ['DOCKERFILE'] = filename
+    dfl = DockerfileLinter()
+    return dfl
+
+def test_docker_from_etcd():
+    Dockerfile_FROM = """FROM registry.fedoraproject.org/f26/etcd"""
+    dfl = prepare_linter(Dockerfile_FROM)
+    assert dfl.check_from_directive_is_valid()
+    os.unlink(os.environ.get('DOCKERFILE'))
+
+def test_docker_from_nginx():
+    Dockerfile_FROM = """FROM registry.access.redhat.com/rhscl/nginx-18-rhel7"""
+    dfl = prepare_linter(Dockerfile_FROM)
+    assert dfl.check_from_directive_is_valid()
+    os.unlink(os.environ.get('DOCKERFILE'))
+
+def test_docker_from_dash():
+    Dockerfile_FROM = """FROM rhel7:7.5-175"""
+    dfl = prepare_linter(Dockerfile_FROM)
+    assert dfl.check_from_directive_is_valid()
+    os.unlink(os.environ.get('DOCKERFILE'))
+
+def test_docker_from_first():
+    Dockerfile_FROM = """FROM rhel7:7.5-175"""
+    dfl = prepare_linter(Dockerfile_FROM)
+    assert dfl.check_from_is_first()
+    os.unlink(os.environ.get('DOCKERFILE'))
+
+def test_docker_from_is_not_first():
+    Dockerfile_FROM = """LABEL name=test\nFROM rhel7:7.5-175"""
+    dfl = prepare_linter(Dockerfile_FROM)
+    assert dfl.check_from_is_first() is False
+    os.unlink(os.environ.get('DOCKERFILE'))

--- a/moduleframework/dockerlinter.py
+++ b/moduleframework/dockerlinter.py
@@ -182,7 +182,7 @@ class DockerfileLinter(object):
         """
         Function checks if FROM directive contains valid format like is specified here
         http://docs.projectatomic.io/container-best-practices/#_line_rule_section
-        Regular expression is: ^[a-z0-9.]+(\/[a-z0-9\D.]+)+$
+        Regular expression is: ^[a-z0-9./-]+(:[a-z0-9.]+)?$
         Example registry:
             registry.fedoraproject.org/f26/etcd
             registry.fedoraproject.org/f26/flannel
@@ -195,7 +195,7 @@ class DockerfileLinter(object):
         correct_format = False
         struct = self.dfp_structure[0]
         if struct.get(INSTRUCT) == 'FROM':
-            p = re.compile("^[a-z0-9.]+(\/[a-z0-9\D.]+)+$")
+            p = re.compile("^[a-z0-9./-]+(:[a-z0-9\D.-]+)?$")
             if p.search(struct.get('value')) is not None:
                 correct_format = True
         return correct_format

--- a/moduleframework/dockerlinter.py
+++ b/moduleframework/dockerlinter.py
@@ -108,7 +108,22 @@ class DockerfileLinter(object):
                 except KeyError:
                     core.print_info("Dockerfile tag %s is not parsed by MTF" % key)
 
+    def get_from_instruction(self):
+        """
+        Function returns FROM instruction from Dockerfile
+        :return: string or None
+        """
+        struct = self.dfp_structure[0]
+        if struct.get(INSTRUCT) == 'FROM':
+            return struct.get('value')
+        else:
+            return None
+
     def get_docker_env(self):
+        """
+        Function returns list of ENV variables or empty list
+        :return: dict
+        """
         return self.docker_dict.get(ENV)
 
     def get_docker_specific_env(self, env_name=None):

--- a/moduleframework/tests/static/dockerfile_lint.py
+++ b/moduleframework/tests/static/dockerfile_lint.py
@@ -9,7 +9,7 @@ class DockerInstructionsTests(module_framework.AvocadoTest):
     """
 
     dp = None
-
+    FROM = "https://docs.docker.com/engine/reference/builder/#from"
     def setUp(self):
         # it is not intended just for docker, but just docker packages are
         # actually properly signed
@@ -18,10 +18,14 @@ class DockerInstructionsTests(module_framework.AvocadoTest):
             self.cancel("Dockerfile was not found")
 
     def test_from_is_first_directive(self):
-        self.assertTrue(self.dp.check_from_is_first(), msg="FROM instruction is not first.\n\tMore info: https://docs.docker.com/engine/reference/builder/#from")
+        self.assertTrue(self.dp.check_from_is_first(),
+                        msg="FROM instruction is not first.\nMore info: %s" % self.FROM)
 
     def test_from_directive_is_valid(self):
-        self.assertTrue(self.dp.check_from_directive_is_valid(), msg="FROM instruction is not valid.\n\tMore info: https://docs.docker.com/engine/reference/builder/#from")
+        reg_exp = '^[a-z0-9.]+(\/[a-z0-9\D.]+)+$'
+        self.assertTrue(self.dp.check_from_directive_is_valid(),
+                        msg="FROM instruction (%s) is not valid. We use reg %s."
+                            "\nMore info: %s" % (self.dp.get_from_instruction(), reg_exp, self.FROM))
 
     def test_chained_run_dnf_commands(self):
         self.assertTrue(self.dp.check_chained_run_dnf_commands(), msg="dnf/yum commands are not chained.\n\tMore info: https://github.com/projectatomic/container-best-practices/blob/master/creating/creating_index.adoc#clearing-package-cache-and-squashing")

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ modulemd
 netifaces
 pdc-client
 pexpect
+pytest


### PR DESCRIPTION
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>

This Pull request adds more information, why FROM instruction is not valid.

New output looks like:
```
TEST FAIL:  ../../moduleframework/tests/static/dockerfile_lint.py:DockerInstructionsTests.test_from_directive_is_valid
     reason -> FROM instruction (baseruntime-*/+54/baseruntime:latest) is not valid. We use reg ^[a-z0-9.]+(\/[a-z0-9\D.]+)+$.
	More info: https://docs.docker.com/engine/reference/builder/#from
     /home/phracek/avocado/job-results/job-2018-03-12T17.25-6f28f24/test-results/02-.._.._moduleframework_tests_static_dockerfile_lint.py_DockerInstructionsTests.test_from_directive_is_valid/debug.log
```