### PR TITLE
release-conf file for Release-Bot

### DIFF
--- a/release-conf.yaml
+++ b/release-conf.yaml
@@ -1,0 +1,7 @@
+python_versions:
+- 2
+fedora: true
+fedora_branches:
+- f29
+- f28
+trigger_on_issue: true


### PR DESCRIPTION
Signed-off-by: Petr "Stone" Hracek <phracek@redhat.com>

This file adds support for Release-Bot automated PyPi and Fedora releases. (https://github.com/user-cont/release-bot)